### PR TITLE
Websockets 12.0, fixed index builder

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,112 +14,126 @@ environment:
   CF_BUCKET_NAME: flet-simple
 
   matrix:
-    - job_name: 'Android arm64-v8a: opencv-python'
-      job_group: build_android
-      FORGE_ARCH: 'android:arm64-v8a'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'Android armeabi-v7a: opencv-python'
-      job_group: build_android
-      FORGE_ARCH: 'android:armeabi-v7a'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'Android x86_64: opencv-python'
-      job_group: build_android
-      FORGE_ARCH: 'android:x86_64'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'Android x86: opencv-python'
-      job_group: build_android
-      FORGE_ARCH: 'android:x86'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'iOS iphone arm64: opencv-python'
-      job_group: build_ios
-      FORGE_ARCH: 'iphoneos:arm64'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'iOS simulator arm64: opencv-python'
-      job_group: build_ios
-      FORGE_ARCH: 'iphonesimulator:arm64'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'iOS simulator x86_64: opencv-python'
-      job_group: build_ios
-      FORGE_ARCH: 'iphonesimulator:x86_64'
-      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    - job_name: 'Android: pydantic-core, pillow, lru-dict, contourpy, kiwisolver, aiohttp, bitarray, argon2-cffi-binding, bcrypt, cryptography, brotli'
+    - job_name: 'Android: websockets'
       job_group: build_android
       FORGE_ARCH: android
       FORGE_PACKAGES: >-
-        cffi:1.16.0
-        libjpeg:3.0.1
-        libpng:1.6.43
-        freetype:2.13.2
-        pillow:10.3.0
-        lru-dict:1.3.0
-        yarl:1.9.4
-        contourpy:1.2.1
-        kiwisolver:1.4.5
-        aiohttp:3.9.5
-        bitarray:2.9.2
-        argon2-cffi-bindings:21.2.0
-        bcrypt:4.1.3
-        cryptography:42.0.7
-        brotli:1.1.0
-        pydantic-core:2.18.4
+        websockets:12.0
 
-    - job_name: 'Android: numpy, matplotlib, pandas, blis'
-      job_group: build_android
-      FORGE_ARCH: android
-      FORGE_PACKAGES: >-
-        numpy:1.26.4
-        numpy:2.0.0
-        matplotlib:3.9.0
-        pandas:2.2.2
-        blis:0.9.1
-
-    - job_name: 'iOS: pillow, lru-dict, yarl, contourpy, kiwisolver, aiohttp, bitarray'
+    - job_name: 'iOS: websockets'
       job_group: build_ios
       FORGE_ARCH: iOS
       FORGE_PACKAGES: >-
-        libjpeg:3.0.1
-        libpng:1.6.43
-        freetype:2.13.2
-        pillow:10.3.0
-        lru-dict:1.3.0
-        yarl:1.9.4
-        contourpy:1.2.1
-        kiwisolver:1.4.5
-        aiohttp:3.9.5
-        bitarray:2.9.2
+        websockets:12.0
 
-    - job_name: 'iOS: cffi, argon2-cffi-bindings, bcrypt, cryptography, brotli'
-      job_group: build_ios
-      FORGE_ARCH: iOS
-      FORGE_PACKAGES:  >-
-        cffi:1.16.0
-        argon2-cffi-bindings:21.2.0
-        bcrypt:4.1.3
-        cryptography:42.0.7
-        brotli:1.1.0
+    # - job_name: 'Android arm64-v8a: opencv-python'
+    #   job_group: build_android
+    #   FORGE_ARCH: 'android:arm64-v8a'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
 
-    - job_name: 'iOS: pydantic-core'
-      job_group: build_ios
-      FORGE_ARCH: iOS
-      FORGE_PACKAGES: >-
-        pydantic-core:2.18.4
+    # - job_name: 'Android armeabi-v7a: opencv-python'
+    #   job_group: build_android
+    #   FORGE_ARCH: 'android:armeabi-v7a'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
 
-    - job_name: 'iOS: numpy, matplotlib, pandas, blis'
-      job_group: build_ios
-      FORGE_ARCH: iOS
-      FORGE_PACKAGES: >-
-        numpy:1.26.4
-        numpy:2.0.0
-        matplotlib:3.9.0
-        pandas:2.2.2
-        blis:0.9.1
+    # - job_name: 'Android x86_64: opencv-python'
+    #   job_group: build_android
+    #   FORGE_ARCH: 'android:x86_64'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    # - job_name: 'Android x86: opencv-python'
+    #   job_group: build_android
+    #   FORGE_ARCH: 'android:x86'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    # - job_name: 'iOS iphone arm64: opencv-python'
+    #   job_group: build_ios
+    #   FORGE_ARCH: 'iphoneos:arm64'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    # - job_name: 'iOS simulator arm64: opencv-python'
+    #   job_group: build_ios
+    #   FORGE_ARCH: 'iphonesimulator:arm64'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    # - job_name: 'iOS simulator x86_64: opencv-python'
+    #   job_group: build_ios
+    #   FORGE_ARCH: 'iphonesimulator:x86_64'
+    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    # - job_name: 'Android: pydantic-core, pillow, lru-dict, contourpy, kiwisolver, aiohttp, bitarray, argon2-cffi-binding, bcrypt, cryptography, brotli, websockets'
+    #   job_group: build_android
+    #   FORGE_ARCH: android
+    #   FORGE_PACKAGES: >-
+    #     cffi:1.16.0
+    #     libjpeg:3.0.1
+    #     libpng:1.6.43
+    #     freetype:2.13.2
+    #     pillow:10.3.0
+    #     lru-dict:1.3.0
+    #     yarl:1.9.4
+    #     contourpy:1.2.1
+    #     kiwisolver:1.4.5
+    #     aiohttp:3.9.5
+    #     bitarray:2.9.2
+    #     argon2-cffi-bindings:21.2.0
+    #     bcrypt:4.1.3
+    #     cryptography:42.0.7
+    #     brotli:1.1.0
+    #     pydantic-core:2.18.4
+    #     websockets:12.0
+
+    # - job_name: 'Android: numpy, matplotlib, pandas, blis'
+    #   job_group: build_android
+    #   FORGE_ARCH: android
+    #   FORGE_PACKAGES: >-
+    #     numpy:1.26.4
+    #     numpy:2.0.0
+    #     matplotlib:3.9.0
+    #     pandas:2.2.2
+    #     blis:0.9.1
+
+    # - job_name: 'iOS: pillow, lru-dict, yarl, contourpy, kiwisolver, aiohttp, bitarray, websockets'
+    #   job_group: build_ios
+    #   FORGE_ARCH: iOS
+    #   FORGE_PACKAGES: >-
+    #     libjpeg:3.0.1
+    #     libpng:1.6.43
+    #     freetype:2.13.2
+    #     pillow:10.3.0
+    #     lru-dict:1.3.0
+    #     yarl:1.9.4
+    #     contourpy:1.2.1
+    #     kiwisolver:1.4.5
+    #     aiohttp:3.9.5
+    #     bitarray:2.9.2
+    #     websockets:12.0
+
+    # - job_name: 'iOS: cffi, argon2-cffi-bindings, bcrypt, cryptography, brotli'
+    #   job_group: build_ios
+    #   FORGE_ARCH: iOS
+    #   FORGE_PACKAGES:  >-
+    #     cffi:1.16.0
+    #     argon2-cffi-bindings:21.2.0
+    #     bcrypt:4.1.3
+    #     cryptography:42.0.7
+    #     brotli:1.1.0
+
+    # - job_name: 'iOS: pydantic-core'
+    #   job_group: build_ios
+    #   FORGE_ARCH: iOS
+    #   FORGE_PACKAGES: >-
+    #     pydantic-core:2.18.4
+
+    # - job_name: 'iOS: numpy, matplotlib, pandas, blis'
+    #   job_group: build_ios
+    #   FORGE_ARCH: iOS
+    #   FORGE_PACKAGES: >-
+    #     numpy:1.26.4
+    #     numpy:2.0.0
+    #     matplotlib:3.9.0
+    #     pandas:2.2.2
+    #     blis:0.9.1
 
     - job_name: Re-build Simple index
       job_group: rebuild_index

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,126 +14,126 @@ environment:
   CF_BUCKET_NAME: flet-simple
 
   matrix:
-    - job_name: 'Android: websockets'
+    # - job_name: 'Android: websockets'
+    #   job_group: build_android
+    #   FORGE_ARCH: android
+    #   FORGE_PACKAGES: >-
+    #     websockets:12.0
+
+    # - job_name: 'iOS: websockets'
+    #   job_group: build_ios
+    #   FORGE_ARCH: iOS
+    #   FORGE_PACKAGES: >-
+    #     websockets:12.0
+
+    - job_name: 'Android arm64-v8a: opencv-python'
+      job_group: build_android
+      FORGE_ARCH: 'android:arm64-v8a'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'Android armeabi-v7a: opencv-python'
+      job_group: build_android
+      FORGE_ARCH: 'android:armeabi-v7a'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'Android x86_64: opencv-python'
+      job_group: build_android
+      FORGE_ARCH: 'android:x86_64'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'Android x86: opencv-python'
+      job_group: build_android
+      FORGE_ARCH: 'android:x86'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'iOS iphone arm64: opencv-python'
+      job_group: build_ios
+      FORGE_ARCH: 'iphoneos:arm64'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'iOS simulator arm64: opencv-python'
+      job_group: build_ios
+      FORGE_ARCH: 'iphonesimulator:arm64'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'iOS simulator x86_64: opencv-python'
+      job_group: build_ios
+      FORGE_ARCH: 'iphonesimulator:x86_64'
+      FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+
+    - job_name: 'Android: pydantic-core, pillow, lru-dict, contourpy, kiwisolver, aiohttp, bitarray, argon2-cffi-binding, bcrypt, cryptography, brotli, websockets'
       job_group: build_android
       FORGE_ARCH: android
       FORGE_PACKAGES: >-
+        cffi:1.16.0
+        libjpeg:3.0.1
+        libpng:1.6.43
+        freetype:2.13.2
+        pillow:10.3.0
+        lru-dict:1.3.0
+        yarl:1.9.4
+        contourpy:1.2.1
+        kiwisolver:1.4.5
+        aiohttp:3.9.5
+        bitarray:2.9.2
+        argon2-cffi-bindings:21.2.0
+        bcrypt:4.1.3
+        cryptography:42.0.7
+        brotli:1.1.0
+        pydantic-core:2.18.4
         websockets:12.0
 
-    - job_name: 'iOS: websockets'
+    - job_name: 'Android: numpy, matplotlib, pandas, blis'
+      job_group: build_android
+      FORGE_ARCH: android
+      FORGE_PACKAGES: >-
+        numpy:1.26.4
+        numpy:2.0.0
+        matplotlib:3.9.0
+        pandas:2.2.2
+        blis:0.9.1
+
+    - job_name: 'iOS: pillow, lru-dict, yarl, contourpy, kiwisolver, aiohttp, bitarray, websockets'
       job_group: build_ios
       FORGE_ARCH: iOS
       FORGE_PACKAGES: >-
+        libjpeg:3.0.1
+        libpng:1.6.43
+        freetype:2.13.2
+        pillow:10.3.0
+        lru-dict:1.3.0
+        yarl:1.9.4
+        contourpy:1.2.1
+        kiwisolver:1.4.5
+        aiohttp:3.9.5
+        bitarray:2.9.2
         websockets:12.0
 
-    # - job_name: 'Android arm64-v8a: opencv-python'
-    #   job_group: build_android
-    #   FORGE_ARCH: 'android:arm64-v8a'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+    - job_name: 'iOS: cffi, argon2-cffi-bindings, bcrypt, cryptography, brotli'
+      job_group: build_ios
+      FORGE_ARCH: iOS
+      FORGE_PACKAGES:  >-
+        cffi:1.16.0
+        argon2-cffi-bindings:21.2.0
+        bcrypt:4.1.3
+        cryptography:42.0.7
+        brotli:1.1.0
 
-    # - job_name: 'Android armeabi-v7a: opencv-python'
-    #   job_group: build_android
-    #   FORGE_ARCH: 'android:armeabi-v7a'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
+    - job_name: 'iOS: pydantic-core'
+      job_group: build_ios
+      FORGE_ARCH: iOS
+      FORGE_PACKAGES: >-
+        pydantic-core:2.18.4
 
-    # - job_name: 'Android x86_64: opencv-python'
-    #   job_group: build_android
-    #   FORGE_ARCH: 'android:x86_64'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    # - job_name: 'Android x86: opencv-python'
-    #   job_group: build_android
-    #   FORGE_ARCH: 'android:x86'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    # - job_name: 'iOS iphone arm64: opencv-python'
-    #   job_group: build_ios
-    #   FORGE_ARCH: 'iphoneos:arm64'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    # - job_name: 'iOS simulator arm64: opencv-python'
-    #   job_group: build_ios
-    #   FORGE_ARCH: 'iphonesimulator:arm64'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    # - job_name: 'iOS simulator x86_64: opencv-python'
-    #   job_group: build_ios
-    #   FORGE_ARCH: 'iphonesimulator:x86_64'
-    #   FORGE_PACKAGES: numpy:2.0.0 opencv-python:4.10.0.84
-
-    # - job_name: 'Android: pydantic-core, pillow, lru-dict, contourpy, kiwisolver, aiohttp, bitarray, argon2-cffi-binding, bcrypt, cryptography, brotli, websockets'
-    #   job_group: build_android
-    #   FORGE_ARCH: android
-    #   FORGE_PACKAGES: >-
-    #     cffi:1.16.0
-    #     libjpeg:3.0.1
-    #     libpng:1.6.43
-    #     freetype:2.13.2
-    #     pillow:10.3.0
-    #     lru-dict:1.3.0
-    #     yarl:1.9.4
-    #     contourpy:1.2.1
-    #     kiwisolver:1.4.5
-    #     aiohttp:3.9.5
-    #     bitarray:2.9.2
-    #     argon2-cffi-bindings:21.2.0
-    #     bcrypt:4.1.3
-    #     cryptography:42.0.7
-    #     brotli:1.1.0
-    #     pydantic-core:2.18.4
-    #     websockets:12.0
-
-    # - job_name: 'Android: numpy, matplotlib, pandas, blis'
-    #   job_group: build_android
-    #   FORGE_ARCH: android
-    #   FORGE_PACKAGES: >-
-    #     numpy:1.26.4
-    #     numpy:2.0.0
-    #     matplotlib:3.9.0
-    #     pandas:2.2.2
-    #     blis:0.9.1
-
-    # - job_name: 'iOS: pillow, lru-dict, yarl, contourpy, kiwisolver, aiohttp, bitarray, websockets'
-    #   job_group: build_ios
-    #   FORGE_ARCH: iOS
-    #   FORGE_PACKAGES: >-
-    #     libjpeg:3.0.1
-    #     libpng:1.6.43
-    #     freetype:2.13.2
-    #     pillow:10.3.0
-    #     lru-dict:1.3.0
-    #     yarl:1.9.4
-    #     contourpy:1.2.1
-    #     kiwisolver:1.4.5
-    #     aiohttp:3.9.5
-    #     bitarray:2.9.2
-    #     websockets:12.0
-
-    # - job_name: 'iOS: cffi, argon2-cffi-bindings, bcrypt, cryptography, brotli'
-    #   job_group: build_ios
-    #   FORGE_ARCH: iOS
-    #   FORGE_PACKAGES:  >-
-    #     cffi:1.16.0
-    #     argon2-cffi-bindings:21.2.0
-    #     bcrypt:4.1.3
-    #     cryptography:42.0.7
-    #     brotli:1.1.0
-
-    # - job_name: 'iOS: pydantic-core'
-    #   job_group: build_ios
-    #   FORGE_ARCH: iOS
-    #   FORGE_PACKAGES: >-
-    #     pydantic-core:2.18.4
-
-    # - job_name: 'iOS: numpy, matplotlib, pandas, blis'
-    #   job_group: build_ios
-    #   FORGE_ARCH: iOS
-    #   FORGE_PACKAGES: >-
-    #     numpy:1.26.4
-    #     numpy:2.0.0
-    #     matplotlib:3.9.0
-    #     pandas:2.2.2
-    #     blis:0.9.1
+    - job_name: 'iOS: numpy, matplotlib, pandas, blis'
+      job_group: build_ios
+      FORGE_ARCH: iOS
+      FORGE_PACKAGES: >-
+        numpy:1.26.4
+        numpy:2.0.0
+        matplotlib:3.9.0
+        pandas:2.2.2
+        blis:0.9.1
 
     - job_name: Re-build Simple index
       job_group: rebuild_index

--- a/.ci/publish-wheels.py
+++ b/.ci/publish-wheels.py
@@ -82,11 +82,11 @@ def main():
         remote_wheel_path = os.path.basename(wheel)
 
         # extract and upload metadata
-        with zipfile.ZipFile(wheel) as zip:
+        with zipfile.ZipFile(wheel) as z:
             metadata_filename = next(
-                filter(lambda f: f.endswith(".dist-info/METADATA"), zip.namelist())
+                filter(lambda f: f.endswith(".dist-info/METADATA"), z.namelist())
             )
-            with zip.open(metadata_filename) as f:
+            with z.open(metadata_filename) as f:
                 metadata = f.read()
                 s3_client.put_object(
                     Key=f"{remote_wheel_path}.metadata",

--- a/.ci/rebuild-simple-index.py
+++ b/.ci/rebuild-simple-index.py
@@ -76,6 +76,7 @@ def main():
         Key="simple/index.html",
         Body="\n".join(lines).encode("utf8"),
         Bucket=cf_bucket_name,
+        ContentType="text/html",
     )
 
     print("Updating package indexes")
@@ -95,6 +96,7 @@ def main():
                 Key=key,
                 Body="\n".join(lines).encode("utf8"),
                 Bucket=cf_bucket_name,
+                ContentType="text/html",
             )
 
 

--- a/.ci/rebuild-simple-index.py
+++ b/.ci/rebuild-simple-index.py
@@ -56,7 +56,7 @@ def main():
                 package_name = parts[1]
             if not package_name in index:
                 index[package_name] = []
-        elif not key.endswith("index.html"):
+        elif not key.endswith("index.html") and key.endswith(".whl"):
             print(key)
             package_name = normalize(key.split("-")[0])
             wheels = index.get(package_name, None)

--- a/.ci/rebuild-simple-index.py
+++ b/.ci/rebuild-simple-index.py
@@ -56,7 +56,7 @@ def main():
                 package_name = parts[1]
             if not package_name in index:
                 index[package_name] = []
-        elif not key.endswith("index.html") and key.endswith(".whl"):
+        elif key.endswith(".whl"):
             print(key)
             package_name = normalize(key.split("-")[0])
             wheels = index.get(package_name, None)

--- a/.ci/rebuild-simple-index.py
+++ b/.ci/rebuild-simple-index.py
@@ -5,7 +5,7 @@ import boto3
 
 html_header = "<!DOCTYPE html><html><body>\n"
 html_root_anchor = '<a href="{0}/">{0}</a></br>\n'
-html_package_anchor = '<a href="https://pypi.flet.dev/{key}#sha256={sha256}" data-dist-info-metadata="sha256={sha256}" data-core-metadata="sha256={sha256}">{key}</a></br>\n'
+html_package_anchor = '<a href="https://pypi.flet.dev/{key}#sha256={wheel_hash}" data-dist-info-metadata="sha256={metadata_hash}" data-core-metadata="sha256={metadata_hash}">{key}</a></br>\n'
 html_footer = "</body></html>\n"
 
 
@@ -64,7 +64,13 @@ def main():
                 wheels = []
                 index[package_name] = wheels
             metadata = s3_client.head_object(Bucket=cf_bucket_name, Key=obj["Key"])
-            wheels.append({"key": key, "sha256": metadata["Metadata"]["sha256"]})
+            wheels.append(
+                {
+                    "key": key,
+                    "wheel_hash": metadata["Metadata"].get("wheel_hash", ""),
+                    "metadata_hash": metadata["Metadata"].get("metadata_hash", ""),
+                }
+            )
 
     print("Writing root index")
     packages = [
@@ -83,7 +89,12 @@ def main():
     for package_name, files in index.items():
         files.sort(key=lambda f: f["key"])
         versions = [
-            html_package_anchor.format(key=f["key"], sha256=f["sha256"]) for f in files
+            html_package_anchor.format(
+                key=f["key"],
+                wheel_hash=f["wheel_hash"],
+                metadata_hash=f["metadata_hash"],
+            )
+            for f in files
         ]
         key = f"simple/{package_name}/index.html"
         if len(versions) == 0:

--- a/recipes/websockets/meta.yaml
+++ b/recipes/websockets/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: websockets
+  version: '12.0'


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces support for Websockets version 12.0, enhances the upload and index builder scripts to handle SHA256 hashes for both wheel files and their metadata, and updates the AppVeyor build configuration to include the new Websockets version.

- **New Features**:
    - Added support for Websockets version 12.0 in the build configurations for both Android and iOS.
- **Enhancements**:
    - Improved the upload script to include SHA256 hashes for both wheel files and their metadata.
    - Enhanced the index builder script to handle and display separate SHA256 hashes for wheel files and their metadata.
- **Build**:
    - Updated the AppVeyor configuration to include Websockets version 12.0 in the build matrix for Android and iOS.

<!-- Generated by sourcery-ai[bot]: end summary -->