### PR TITLE
fix(numpy): add Android `flet-libcpp-shared` host dep

### DIFF
--- a/recipes/numpy/meta.yaml
+++ b/recipes/numpy/meta.yaml
@@ -8,6 +8,10 @@ package:
 requirements:
  build:
   - ninja
+{% if sdk == 'android' %}
+ host:
+  - flet-libcpp-shared >=27.2.12479018
+{% endif %}
 
 patches:
 {% if version and version < (2, 0) %}

--- a/recipes/numpy/meta.yaml
+++ b/recipes/numpy/meta.yaml
@@ -21,6 +21,7 @@ patches:
 {% endif %}
 
 build:
+  number: 5
   script_env:
     NPY_DISABLE_SVML: 1
 

--- a/recipes/numpy/test_numpy.py
+++ b/recipes/numpy/test_numpy.py
@@ -20,3 +20,26 @@ def test_performance():
     duration = time() - start_time
     print(f"{duration:.3f}")
     assert duration < 0.7
+
+
+def test_fft():
+    """Forces _pocketfft_umath.so to load — the canary for the libc++_shared
+    Android dep."""
+    import numpy as np
+
+    # 8-point FFT of a pure cosine at frequency k=2. The real-input FFT of
+    # cos(2π · k · n / N) has two equal-magnitude peaks at bins k and N-k.
+    x = np.cos(2 * np.pi * 2 * np.arange(8) / 8)
+    spectrum = np.fft.fft(x)
+    magnitudes = np.abs(spectrum)
+
+    # Peaks at bins 2 and 6 with magnitude N/2 = 4 for unit-amplitude cosine.
+    assert magnitudes[2] > 3.9, f"bin 2 magnitude = {magnitudes[2]}"
+    assert magnitudes[6] > 3.9, f"bin 6 magnitude = {magnitudes[6]}"
+    # All other bins should be ~0 (within fp noise).
+    other = max(float(magnitudes[i]) for i in (0, 1, 3, 4, 5, 7))
+    assert other < 1e-6, f"unexpected non-zero bin: {other}"
+
+    # Round-trip: inverse FFT recovers the original signal.
+    recovered = np.fft.ifft(spectrum).real
+    assert np.allclose(recovered, x)


### PR DESCRIPTION
## Description

Published `numpy-2.2.2-*-android_*.whl` on pypi.flet.dev requires `libc++_shared.so` at runtime (verified via `llvm-readobj --needed-libs`) but doesn't declare it in METADATA. Apps using numpy alone crash at `import numpy` on x86_64, or at `np.fft.*` on arm64, with:

    dlopen failed: library "libc++_shared.so" not found

| wheel | `_multiarray_umath` needs libcpp | `_pocketfft_umath` needs libcpp |
|---|---|---|
| arm64-v8a (builds 2, 4) | no | yes |
| x86_64 (builds 2, 4) | **yes** | yes |

## Repro

Android Emulator: v15, API level 35, model sdk_gphone64_arm64, ABI arm64-v8a

<img width="541" height="1031" alt="image" src="https://github.com/user-attachments/assets/9b0c25a8-4512-46ac-aad4-5724cf2500c2" />

<details><summary>Error message</summary>
<p>

```
✗ fft
   ImportError: dlopen failed: library "libc++_shared.so" not
   found: needed by /data/data/com.flet.numpy_emu_verify/files/flet/
   python_site_packages/numpy/fft/_pocketfft_umath.cpython-312.so in
   namespace clns-7
   
   Traceback (most recent call last):
     ...
     File "...numpy/fft/_pocketfft.py", line 39, in <module>
       import _pocketfft_umath as pfu
   ImportError: dlopen failed: library "libc++_shared.so" not found:
   needed by .../numpy/fft/_pocketfft_umath.cpython-312.so
```

</p>
</details> 

<details><summary>Code</summary>
<p>

```python
# main.py
import flet as ft


def step_import() -> dict:
    """The core question: does numpy import?"""
    import numpy as np

    return {
        "step": "import numpy",
        "ok": True,
        "detail": f"numpy {np.__version__}",
    }


def step_array_op() -> dict:
    """Simplest end-to-end numpy op — exercises _multiarray_umath."""
    from numpy import array

    result = (array([1, 2]) + array([3, 5])).tolist()
    ok = result == [4, 7]
    return {
        "step": "array([1,2]) + array([3,5])",
        "ok": ok,
        "detail": f"= {result}  (expected [4, 7])",
    }


def step_random() -> dict:
    """Exercises numpy/random/* C extensions."""
    import numpy as np

    rng = np.random.default_rng(seed=42)
    samples = rng.standard_normal(1000)
    mean = float(samples.mean())
    std = float(samples.std())
    # With seed 42 and n=1000 we expect mean ~0, std ~1; loose bounds.
    ok = abs(mean) < 0.2 and 0.8 < std < 1.2
    return {
        "step": "np.random.default_rng standard_normal(1000)",
        "ok": ok,
        "detail": f"mean={mean:.4f}  std={std:.4f}  (expected ~0, ~1)",
    }


def step_linalg() -> dict:
    """Exercises numpy/linalg/_umath_linalg — also confirms BLAS-free build works."""
    import numpy as np

    A = np.array([[1.0, 2.0], [3.0, 4.0]])
    eigvals = sorted(float(v.real) for v in np.linalg.eigvals(A))
    # Eigenvalues of [[1,2],[3,4]] are (5 ± sqrt(33)) / 2 ≈ -0.372, 5.372
    expected = [-0.372, 5.372]
    ok = all(abs(a - b) < 0.01 for a, b in zip(eigvals, expected))
    return {
        "step": "np.linalg.eigvals([[1,2],[3,4]])",
        "ok": ok,
        "detail": f"= {[round(v, 3) for v in eigvals]}  (expected ≈ {expected})",
    }


def step_fft() -> dict:
    """np.fft.fft triggers _pocketfft_umath.so — links libc++_shared on EVERY
    Android arch. If libcpp isn't bundled, this step shows RED with the
    `dlopen failed: library "libc++_shared.so" not found` traceback."""
    import numpy as np

    # 8-point FFT of pure cos(2π · 2 · n / 8): real-input FFT has equal-
    # magnitude peaks at bins 2 and 6 (N/2 = 4 for unit cosine).
    x = np.cos(2 * np.pi * 2 * np.arange(8) / 8)
    spectrum = np.fft.fft(x)
    magnitudes = np.abs(spectrum)
    ok = (
        magnitudes[2] > 3.9
        and magnitudes[6] > 3.9
        and max(float(magnitudes[i]) for i in (0, 1, 3, 4, 5, 7)) < 1e-6
    )
    return {
        "step": "np.fft.fft (_pocketfft_umath.so → libc++_shared.so)",
        "ok": ok,
        "detail": (
            f"|FFT(cos(2π·2·n/8))| peaks: "
            f"bin2={magnitudes[2]:.3f}, bin6={magnitudes[6]:.3f} (expected ≈ 4)"
        ),
    }


def collect_all() -> list[dict]:
    results = []
    for fn in (step_import, step_array_op, step_random, step_linalg, step_fft):
        try:
            results.append(fn())
        except Exception as e:
            import traceback

            results.append(
                {
                    "step": fn.__name__.replace("step_", ""),
                    "ok": False,
                    "detail": f"{type(e).__name__}: {e}",
                    "trace": traceback.format_exc(),
                }
            )
    return results


def build_view(results: list[dict]) -> list[ft.Control]:
    cards = []
    for r in results:
        ok = r["ok"]
        color = ft.Colors.GREEN if ok else ft.Colors.RED
        body = [
            ft.Text(
                f"{'✓' if ok else '✗'}  {r['step']}",
                size=13,
                weight=ft.FontWeight.BOLD,
                color=color,
            ),
            ft.Text(
                r["detail"],
                size=11,
                color=ft.Colors.GREY,
                selectable=True,
                font_family="Courier",
            ),
        ]
        if not ok and "trace" in r:
            body.append(
                ft.Container(
                    content=ft.Text(
                        r["trace"], font_family="Courier", size=10, selectable=True
                    ),
                    padding=8,
                    bgcolor=ft.Colors.RED_50,
                    border_radius=4,
                )
            )
        cards.append(
            ft.Container(
                content=ft.Column(body, spacing=3),
                padding=12,
                margin=ft.Margin.only(bottom=8),
                bgcolor=ft.Colors.BLACK_12,
                border_radius=8,
            )
        )
    return cards


def main(page: ft.Page) -> None:
    page.appbar = ft.AppBar(title=ft.Text("numpy on Android"))
    page.scroll = ft.ScrollMode.AUTO

    results = collect_all()
    n_ok = sum(r["ok"] for r in results)
    page.add(
        ft.Text(
            f"flet {ft.__version__}  •  {n_ok}/{len(results)} steps ok",
            size=15,
            weight=ft.FontWeight.BOLD,
            color=ft.Colors.GREEN if n_ok == len(results) else ft.Colors.AMBER,
        ),
        *build_view(results),
    )


ft.run(main)
```

```toml
[project]
name = "numpy-test"
version = "0.1.0"
description = ""
requires-python = ">=3.10"

dependencies = [
    "flet",
    "numpy==2.2.2",
]

[dependency-groups]
dev = [
    "flet[all]",
]

[tool.flet.app]
path = "."
```

</p>
</details> 

## Changes

- `recipes/numpy/meta.yaml`: conditional `flet-libcpp-shared >=27.2.12479018` Android host dep + `build.number: 5`
- `recipes/numpy/test_numpy.py`: new `test_fft()` canary — forces `_pocketfft_umath.so` to load. Without it the regression sneaks past arm64 CI (where `_multiarray_umath` doesn't link libcpp).

## Effect

After merge, publishes `numpy-2.2.2-5-...whl` with `Requires-Dist: flet-libcpp-shared (>=27.2.12479018)`. Users' next `flet build apk` then auto-pulls libcpp and `copyOpt` surfaces `libc++_shared.so` into `lib/<abi>/`. No user-side change.

**iOS unaffected — Apple's system libc++ is always linked.**