### PR TITLE
Make `meta.yaml` the source of truth for `build.number`

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -13,10 +13,6 @@ on:
         description: "Packages (comma-separated, e.g. pillow:11.1.0,pydantic-core:2.33.2)"
         required: false
         default: "pydantic-core:2.33.2"
-      build_number:
-        description: "Build number"
-        required: false
-        default: "1"
       publish:
         description: "Publish to PyPI"
         type: boolean
@@ -70,7 +66,6 @@ jobs:
         run: |
           ARCHS="${{ inputs.archs || 'android,iOS' }}"
           PACKAGES="${{ steps.detect-packages.outputs.packages }}"
-          BUILD_NUMBER="${{ inputs.build_number || '1' }}"
 
           matrix='{"include":['
           first=true
@@ -87,7 +82,7 @@ jobs:
                 platform="ios"
                 rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
               fi
-              matrix+="{\"job_name\":\"${platform}: ${pkg_name}\",\"artifact_name\":\"${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"build_number\":\"$BUILD_NUMBER\",\"rust_targets\":\"$rust_targets\"}"
+              matrix+="{\"job_name\":\"${platform}: ${pkg_name}\",\"artifact_name\":\"${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"rust_targets\":\"$rust_targets\"}"
             done
           done
           matrix+=']}'
@@ -118,7 +113,6 @@ jobs:
         env:
           FORGE_ARCH: ${{ matrix.forge_arch }}
           FORGE_PACKAGES: ${{ matrix.forge_packages }}
-          BUILD_NUMBER: ${{ matrix.build_number }}
           PLATFORM: ${{ matrix.platform }}
         run: |
           set -euxo pipefail
@@ -152,7 +146,7 @@ jobs:
 
           IFS=' ' read -r -a packages <<< "$FORGE_PACKAGES"
           for package in "${packages[@]}"; do
-            forge "$FORGE_ARCH" "$package:$BUILD_NUMBER"
+            forge "$FORGE_ARCH" "$package"
           done
 
           # Drop the support-tree dep wheels produced by make_dep_wheels.py

--- a/recipes/aiohttp/meta.yaml
+++ b/recipes/aiohttp/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: aiohttp
   version: 3.9.5
+
+build:
+  number: 4

--- a/recipes/argon2-cffi-bindings/meta.yaml
+++ b/recipes/argon2-cffi-bindings/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: argon2-cffi-bindings
   version: 21.2.0
+
+build:
+  number: 4

--- a/recipes/bcrypt/meta.yaml
+++ b/recipes/bcrypt/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 4.2.0
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/biopython/meta.yaml
+++ b/recipes/biopython/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: biopython
   version: "1.87"
+
+build:
+  number: 0

--- a/recipes/bitarray/meta.yaml
+++ b/recipes/bitarray/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: bitarray
   version: 3.6.1
+
+build:
+  number: 4

--- a/recipes/blis/meta.yaml
+++ b/recipes/blis/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: blis
   version: 1.0.0
 
+build:
+  number: 4
+
 requirements:
   host:
     - numpy ^2.0.0

--- a/recipes/brotli/meta.yaml
+++ b/recipes/brotli/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: Brotli
   version: 1.1.0
+
+build:
+  number: 4

--- a/recipes/cffi/meta.yaml
+++ b/recipes/cffi/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: cffi
   version: 1.17.1
 
+build:
+  number: 4
+
 requirements:
   host:
     - libffi

--- a/recipes/contourpy/meta.yaml
+++ b/recipes/contourpy/meta.yaml
@@ -14,6 +14,7 @@ requirements:
 # {% endif %}
 
 build:
+  number: 5
   backend-args:
     - -Csetup-args=--cross-file
     - -Csetup-args={MESON_CROSS_FILE}

--- a/recipes/coolprop/meta.yaml
+++ b/recipes/coolprop/meta.yaml
@@ -13,9 +13,10 @@ requirements:
 patches:
   - mkdir-cython-output.patch
 
-# {% if sdk == 'android' %}
 build:
+  number: 1
   script_env:
+# {% if sdk == 'android' %}
     CMAKE_ARGS: >-
       -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake
       -DANDROID_ABI={ANDROID_ABI}
@@ -28,8 +29,6 @@ build:
       -DPython3_LIBRARY={prefix}/lib/libpython{py_version_short}.so
       -DPython3_INCLUDE_DIR={prefix}/include/python{py_version_short}
 # {% else %}
-build:
-  script_env:
     CMAKE_ARGS: >-
       -DCMAKE_SYSTEM_NAME=iOS
       -DCMAKE_OSX_SYSROOT={{ sdk }}

--- a/recipes/cryptography/meta.yaml
+++ b/recipes/cryptography/meta.yaml
@@ -7,6 +7,7 @@ requirements:
     - openssl ^3.0.12
 
 build:
+  number: 4
   script_env:
     OPENSSL_DIR: '{platlib}/opt'
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/fiona/meta.yaml
+++ b/recipes/fiona/meta.yaml
@@ -7,6 +7,7 @@ requirements:
     - flet-libgdal 3.10.0
 
 build:
+  number: 4
   script_env:
     GDAL_VERSION: 3.10.0
     GDAL_LIB_PATH: '{platlib}/opt/lib'

--- a/recipes/flet-libcpp-shared/meta.yaml
+++ b/recipes/flet-libcpp-shared/meta.yaml
@@ -2,5 +2,8 @@ package:
   name: flet-libcpp-shared
   version: 27.3.13750724
 
+build:
+  number: 4
+
 source:
   url: https://github.com/flet-dev/awesome-flet/archive/refs/heads/main.zip

--- a/recipes/flet-libcrc32c/meta.yaml
+++ b/recipes/flet-libcrc32c/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.1.2
 
 build:
-  number: 1
+  number: 4
 
 source:
   url: https://github.com/google/crc32c/archive/refs/tags/1.1.2.tar.gz

--- a/recipes/flet-libcurl/meta.yaml
+++ b/recipes/flet-libcurl/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://curl.se/download/curl-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   host:

--- a/recipes/flet-libfreetype/meta.yaml
+++ b/recipes/flet-libfreetype/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 2.13.3
 
 build:
-  number: 1
+  number: 2
 
 source:
   url: https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz

--- a/recipes/flet-libgdal/meta.yaml
+++ b/recipes/flet-libgdal/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/OSGeo/gdal/releases/download/v{{ version }}/gdal-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   build:

--- a/recipes/flet-libgeos/meta.yaml
+++ b/recipes/flet-libgeos/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 3.13.0
 
 build:
-  number: 1
+  number: 4
 
 source:
   url: http://download.osgeo.org/geos/geos-3.13.0.tar.bz2

--- a/recipes/flet-libjpeg/meta.yaml
+++ b/recipes/flet-libjpeg/meta.yaml
@@ -6,7 +6,7 @@ source:
   url: https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/3.0.90/libjpeg-turbo-3.0.90.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   build:

--- a/recipes/flet-libjq/meta.yaml
+++ b/recipes/flet-libjq/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/jqlang/jq/releases/download/jq-{{ version }}/jq-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   build:

--- a/recipes/flet-libopaque/meta.yaml
+++ b/recipes/flet-libopaque/meta.yaml
@@ -4,6 +4,9 @@ package:
   name: flet-libopaque
   version: '{{ version }}'
 
+build:
+  number: 4
+
 source:
   url: https://github.com/stef/libopaque/archive/refs/tags/v{{ version }}.tar.gz
 

--- a/recipes/flet-liboprf/meta.yaml
+++ b/recipes/flet-liboprf/meta.yaml
@@ -12,6 +12,7 @@ requirements:
     - flet-libsodium 1.0.20
 
 build:
+  number: 4
   script_env:
     CFLAGS: '-Qunused-arguments -Wno-unreachable-code'
 

--- a/recipes/flet-libpng/meta.yaml
+++ b/recipes/flet-libpng/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.6.43
 
 build:
-  number: 1
+  number: 4
 
 source:
   url: https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.43.tar.gz

--- a/recipes/flet-libproj/meta.yaml
+++ b/recipes/flet-libproj/meta.yaml
@@ -8,7 +8,11 @@ source:
   url: https://download.osgeo.org/proj/proj-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
+# {% if sdk != 'android' %}
+  script_env:
+    LDFLAGS: '-undefined dynamic_lookup'
+# {% endif %}
 
 requirements:
   build:
@@ -16,9 +20,3 @@ requirements:
   host:
     - flet-libtiff 4.7.0
     - flet-libcurl 8.11.0
-
-# {% if sdk != 'android' %}
-build:
-  script_env:
-    LDFLAGS: '-undefined dynamic_lookup'
-# {% endif %}

--- a/recipes/flet-libpsl/meta.yaml
+++ b/recipes/flet-libpsl/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://github.com/rockdaboot/libpsl/releases/download/{{ version }}/libpsl-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 patches:
   - config.patch

--- a/recipes/flet-libpyjni/meta.yaml
+++ b/recipes/flet-libpyjni/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: 1.0.1
 
 build:
-  number: 1
+  number: 4
 
 source:
   url: https://github.com/flet-dev/libpyjni/releases/download/v1.0.1/pyjni-1.0.1.tar.gz

--- a/recipes/flet-libsodium/meta.yaml
+++ b/recipes/flet-libsodium/meta.yaml
@@ -4,5 +4,8 @@ package:
   name: flet-libsodium
   version: '{{ version }}'
 
+build:
+  number: 4
+
 source:
   url: https://github.com/jedisct1/libsodium/releases/download/{{ version }}-RELEASE/libsodium-{{ version }}.tar.gz

--- a/recipes/flet-libtiff/meta.yaml
+++ b/recipes/flet-libtiff/meta.yaml
@@ -8,7 +8,7 @@ source:
   url: https://download.osgeo.org/libtiff/tiff-{{ version }}.tar.gz
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   host:

--- a/recipes/flet-libxml2/meta.yaml
+++ b/recipes/flet-libxml2/meta.yaml
@@ -9,6 +9,9 @@ package:
   name: flet-libxml2
   version: '{{ version }}'
 
+build:
+  number: 1
+
 source:
   url: https://download.gnome.org/sources/libxml2/{{ version.rsplit('.', 1)[0] }}/libxml2-{{ version }}.tar.xz
 

--- a/recipes/flet-libxslt/meta.yaml
+++ b/recipes/flet-libxslt/meta.yaml
@@ -11,6 +11,9 @@ package:
   name: flet-libxslt
   version: '{{ version }}'
 
+build:
+  number: 1
+
 source:
   url: https://download.gnome.org/sources/libxslt/{{ version.rsplit('.', 1)[0] }}/libxslt-{{ version }}.tar.xz
 

--- a/recipes/gdal/meta.yaml
+++ b/recipes/gdal/meta.yaml
@@ -7,6 +7,7 @@ requirements:
     - flet-libgdal 3.10.0
 
 build:
+  number: 4
   script_env:
     GDAL_VERSION: 3.10.0
     GDAL_PREFIX: '{platlib}/opt'

--- a/recipes/google-crc32c/meta.yaml
+++ b/recipes/google-crc32c/meta.yaml
@@ -6,8 +6,9 @@ requirements:
   host:
     - flet-libcrc32c 1.1.2
 
-# {% if sdk != 'android' %}
 build:
+  number: 4
+# {% if sdk != 'android' %}
   script_env:
     LDFLAGS: '-lc++'
 # {% endif %}

--- a/recipes/greenlet/meta.yaml
+++ b/recipes/greenlet/meta.yaml
@@ -2,8 +2,9 @@ package:
   name: greenlet
   version: 3.1.1
 
-# {% if sdk != 'android' %}
 build:
+  number: 4
+# {% if sdk != 'android' %}
   script_env:
     CXXFLAGS: -std=c++14
 # {% endif %}

--- a/recipes/grpcio/meta.yaml
+++ b/recipes/grpcio/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 1.67.1
 
 build:
+  number: 5
   script_env:
 # {% if sdk == 'android' %}
     GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: '1'

--- a/recipes/jiter/meta.yaml
+++ b/recipes/jiter/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 0.8.2
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/jq/meta.yaml
+++ b/recipes/jq/meta.yaml
@@ -7,5 +7,6 @@ requirements:
     - flet-libjq 1.7.1
 
 build:
+  number: 4
   script_env:
     JQPY_USE_SYSTEM_LIBS: 1

--- a/recipes/kiwisolver/meta.yaml
+++ b/recipes/kiwisolver/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: kiwisolver
   version: 1.4.7
 
+build:
+  number: 4
+
 # {% if sdk == 'android' %}
 requirements:
   host:

--- a/recipes/lru-dict/meta.yaml
+++ b/recipes/lru-dict/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: lru-dict
   version: 1.3.0
+
+build:
+  number: 4

--- a/recipes/lxml/meta.yaml
+++ b/recipes/lxml/meta.yaml
@@ -12,6 +12,7 @@ package:
   version: '{{ version }}'
 
 build:
+  number: 1
   script_env:
     WITH_XML2_CONFIG: '{platlib}/opt/bin/xml2-config'
     WITH_XSLT_CONFIG: '{platlib}/opt/bin/xslt-config'

--- a/recipes/markupsafe/meta.yaml
+++ b/recipes/markupsafe/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: MarkupSafe
   version: 2.1.5
+
+build:
+  number: 4

--- a/recipes/matplotlib/meta.yaml
+++ b/recipes/matplotlib/meta.yaml
@@ -12,6 +12,7 @@ requirements:
     - flet-libjpeg 3.0.90
 
 build:
+  number: 4
 # {% if sdk == 'android' and arch in ['armeabi-v7a', 'x86'] %}
   script_env:
     CPPFLAGS: -Wno-c++11-narrowing

--- a/recipes/msgpack/meta.yaml
+++ b/recipes/msgpack/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: msgpack
   version: 1.1.0
+
+build:
+  number: 4

--- a/recipes/msgspec/meta.yaml
+++ b/recipes/msgspec/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: msgspec
   version: 0.18.6
 
+build:
+  number: 4
+
 requirements:
   build:
     - setuptools ^69.5.1

--- a/recipes/numpy/meta.yaml
+++ b/recipes/numpy/meta.yaml
@@ -17,6 +17,7 @@ patches:
 {% endif %}
 
 build:
+  number: 4
   script_env:
     NPY_DISABLE_SVML: 1
 

--- a/recipes/opaque/meta.yaml
+++ b/recipes/opaque/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: opaque
   version: 0.2.0
 
+build:
+  number: 4
+
 requirements:
   host:
     - flet-libopaque 0.99.8

--- a/recipes/opencv-python/meta.yaml
+++ b/recipes/opencv-python/meta.yaml
@@ -9,9 +9,10 @@ requirements:
 patches:
   - mobile.patch
 
-# {% if sdk == 'android' %}
 build:
+  number: 4
   script_env:
+# {% if sdk == 'android' %}
     CMAKE_ARGS: >-
       -DANDROID=ON
       -DWITH_IPP=OFF
@@ -34,8 +35,6 @@ build:
       -DPYTHON3_LIBRARIES={prefix}/lib/libpython{py_version_short}.so
       -DPYTHON3_NUMPY_INCLUDE_DIRS={platlib}/numpy/_core/include
 # {% else %}
-build:
-  script_env:
     CMAKE_ARGS: >-
       -DAPPLE_FRAMEWORK=ON
       -DCMAKE_SYSTEM_NAME=iOS

--- a/recipes/orjson/meta.yaml
+++ b/recipes/orjson/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 3.11.9
 
 build:
+  number: 1
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/pandas/meta.yaml
+++ b/recipes/pandas/meta.yaml
@@ -19,6 +19,7 @@ patches:
   - mobile.patch
 
 build:
+  number: 4
   backend-args:
     - -Csetup-args=--cross-file
     - -Csetup-args={MESON_CROSS_FILE}

--- a/recipes/pendulum/meta.yaml
+++ b/recipes/pendulum/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 3.0.0
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'
 # {% if sdk == 'iphonesimulator' %}

--- a/recipes/pillow/meta.yaml
+++ b/recipes/pillow/meta.yaml
@@ -22,8 +22,9 @@ patches:
 
 # {% endif %}
 
-# {% if sdk != 'android' %}
 build:
+  number: 4
+# {% if sdk != 'android' %}
   script_env:
     # libfreetype references both libz and libbz2
     # but doesn't link them into the static library

--- a/recipes/primp/meta.yaml
+++ b/recipes/primp/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: primp
   version: 1.3.1
+
+build:
+  number: 1

--- a/recipes/protobuf/meta.yaml
+++ b/recipes/protobuf/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: protobuf
   version: 5.28.3
+
+build:
+  number: 4

--- a/recipes/pycryptodome/meta.yaml
+++ b/recipes/pycryptodome/meta.yaml
@@ -2,5 +2,8 @@ package:
   name: pycryptodome
   version: 3.21.0
 
+build:
+  number: 4
+
 patches:
   - mobile.patch

--- a/recipes/pycryptodomex/meta.yaml
+++ b/recipes/pycryptodomex/meta.yaml
@@ -2,5 +2,8 @@ package:
   name: pycryptodomex
   version: 3.21.0
 
+build:
+  number: 4
+
 patches:
   - mobile.patch

--- a/recipes/pydantic-core/meta.yaml
+++ b/recipes/pydantic-core/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 2.33.2
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/pyjnius/meta.yaml
+++ b/recipes/pyjnius/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: pyjnius
   version: 1.6.1
 
+build:
+  number: 4
+
 patches:
   - mobile.patch
 

--- a/recipes/pymongo/meta.yaml
+++ b/recipes/pymongo/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: pymongo
   version: 4.10.1
+
+build:
+  number: 4

--- a/recipes/pynacl/meta.yaml
+++ b/recipes/pynacl/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: PyNaCl
   version: 1.5.0
 
+build:
+  number: 4
+
 requirements:
   host:
     - flet-libsodium 1.0.20

--- a/recipes/pyobjus/meta.yaml
+++ b/recipes/pyobjus/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: pyobjus
   version: 1.2.3
   
+build:
+  number: 1
+
 patches:
   - mobile.patch
 

--- a/recipes/pyogrio/meta.yaml
+++ b/recipes/pyogrio/meta.yaml
@@ -7,6 +7,7 @@ requirements:
     - flet-libgdal 3.10.0
 
 build:
+  number: 4
   script_env:
     GDAL_VERSION: 3.10.0
     GDAL_LIBRARY_PATH: '{platlib}/opt/lib'

--- a/recipes/pyproj/meta.yaml
+++ b/recipes/pyproj/meta.yaml
@@ -3,6 +3,7 @@ package:
   version: 3.7.0
 
 build:
+  number: 4
   script_env:
     PROJ_VERSION: 9.5.0
     PROJ_DIR: '{platlib}/opt'

--- a/recipes/pysodium/meta.yaml
+++ b/recipes/pysodium/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: pysodium
   version: 0.7.18
 
+build:
+  number: 4
+
 requirements:
   host:
     - flet-libsodium 1.0.20

--- a/recipes/pyyaml/meta.yaml
+++ b/recipes/pyyaml/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: PyYAML
   version: 6.0.2
+
+build:
+  number: 4

--- a/recipes/rasterio/meta.yaml
+++ b/recipes/rasterio/meta.yaml
@@ -11,6 +11,7 @@ requirements:
 # {% endif %}
 
 build:
+  number: 2
   script_env:
     GDAL_VERSION: 3.10.0
     GDAL_LIB_PATH: '{platlib}/opt/lib'

--- a/recipes/regex/meta.yaml
+++ b/recipes/regex/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: regex
   version: 2024.11.6
+
+build:
+  number: 4

--- a/recipes/rpds-py/meta.yaml
+++ b/recipes/rpds-py/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 0.23.1
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/ruamel.yaml.clib/meta.yaml
+++ b/recipes/ruamel.yaml.clib/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: ruamel.yaml.clib
   version: 0.2.12
+
+build:
+  number: 1

--- a/recipes/selectolax/meta.yaml
+++ b/recipes/selectolax/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: selectolax
   version: 0.4.10
+
+build:
+  number: 0

--- a/recipes/shapely/meta.yaml
+++ b/recipes/shapely/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: shapely
   version: 2.0.6
 
+build:
+  number: 4
+
 requirements:
   host:
     - flet-libgeos 3.13.0

--- a/recipes/sqlalchemy/meta.yaml
+++ b/recipes/sqlalchemy/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: sqlalchemy
   version: 2.0.36
+
+build:
+  number: 4

--- a/recipes/tiktoken/meta.yaml
+++ b/recipes/tiktoken/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 0.9.0
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/time-machine/meta.yaml
+++ b/recipes/time-machine/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: time-machine
   version: 2.16.0
+
+build:
+  number: 4

--- a/recipes/tokenizers/meta.yaml
+++ b/recipes/tokenizers/meta.yaml
@@ -3,5 +3,6 @@ package:
   version: 0.21.0
 
 build:
+  number: 4
   script_env:
     _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/ujson/meta.yaml
+++ b/recipes/ujson/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: ujson
   version: 5.12.1
 
+build:
+  number: 1
+
 # {% if sdk == 'android' %}
 # ujson links its bundled double-conversion C++ code against NDK's libc++.
 # NDK r27 defaults to libc++_shared, so the .so has a runtime dlopen() on

--- a/recipes/websockets/meta.yaml
+++ b/recipes/websockets/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: websockets
   version: 13.0.1
+
+build:
+  number: 4

--- a/recipes/yarl/meta.yaml
+++ b/recipes/yarl/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: yarl
   version: 1.11.1
 
+build:
+  number: 4
+
 requirements:
   build:
     - cython

--- a/recipes/zope.interface/meta.yaml
+++ b/recipes/zope.interface/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: zope.interface
   version: '7.2'
+
+build:
+  number: 4

--- a/recipes/zstandard/meta.yaml
+++ b/recipes/zstandard/meta.yaml
@@ -1,3 +1,6 @@
 package:
   name: zstandard
   version: 0.23.0
+
+build:
+  number: 4


### PR DESCRIPTION
## Summary

- Remove the `build_number` workflow_dispatch input. forge now reads `build.number` straight from each recipe's `meta.yaml`.
- Set `build.number` explicitly in every recipe (78 files), matching the current pypi.flet.dev max for that version.

## Why

Build bumps now go through normal git review — every published wheel is tied to a reviewable commit.

## Preferably Skip CI after merge

pypi.flet.dev already has working wheels at the declared build numbers; the merge commit will trigger a "useless" rebuild which would just produce (and attempt to publish) identical wheels. Future per-recipe bumps (`build.number: N+1`) will trigger normal CI rebuild + publish for that recipe alone.

## Pre-flight

All 78 changed recipes pass forge's `Package.load_meta` under both android and iOS render contexts — Jinja + YAML + schema validation green, zero arch-divergent `build.number`.