### PR TITLE
Preserve upstream wheel Python/ABI tag (fixes abi3 wheel naming)

### DIFF
--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -649,11 +649,21 @@ class Builder(ABC):
 
         # Normalize wheel tags to forge platform tags so repacked wheels use
         # android_24_arm64_v8a / ios_13_0_arm64_iphoneos style platform tags.
+        # Preserve the Python/ABI part the upstream build wrote (e.g. maturin
+        # emits `cp37-abi3-*` for cryptography); only the platform component
+        # is swapped. Falls back to self.wheel_tag when no Tag was written.
         wheel_metadata_path = next(wheel_dir.glob("*.dist-info")) / "WHEEL"
         wheel_metadata = self.read_message_file(wheel_metadata_path)
-        if "Tag" in wheel_metadata:
-            del wheel_metadata["Tag"]
-        wheel_metadata["Tag"] = self.wheel_tag
+        upstream_tags = wheel_metadata.get_all("Tag", [])
+        del wheel_metadata["Tag"]
+        new_tags = []
+        for tag in upstream_tags:
+            py, abi, _platform = tag.rsplit("-", 2)
+            new_tags.append(f"{py}-{abi}-{self.cross_venv.tag}")
+        if not new_tags:
+            new_tags = [self.wheel_tag]
+        for tag in new_tags:
+            wheel_metadata["Tag"] = tag
         self.write_message_file(wheel_metadata_path, wheel_metadata)
 
         if self.cross_venv.sdk == "android":


### PR DESCRIPTION
## Summary

`fix_wheel` was unconditionally rewriting the `WHEEL` metadata Tag with `self.wheel_tag` (`cp3X-cp3X-<platform>`), discarding the tag maturin / the upstream build backend had emitted. For abi3 crates like cryptography this turned `cp37-abi3-<platform>` into `cp312-cp312-<platform>`, and the produced wheel filename followed (since `wheel pack` derives the name from the Tag).

Visible on `pypi.flet.dev` today:

- Oct/Nov 2024 cryptography wheels: `cryptography-43.0.1-1-cp37-abi3-android_24_*.whl` ✓
- Mar 2026 cryptography wheels: `cryptography-43.0.1-4-cp312-cp312-android_24_*.whl` ✗

The regression came in with [4cf1c1f (GHA for Python 3.12 #46)](https://github.com/flet-dev/mobile-forge/commit/4cf1c1f) — the "Normalize wheel tags…" sub-commit that introduced [`PythonPackageBuilder.wheel_tag`](src/forge/build.py#L873-L876) and started clobbering the upstream Tag in `fix_wheel`.

## Why the old tagging was wrong

- **Semantically incorrect**: the inner `_rust.abi3.so` is stable-ABI; the wheel claimed cp312-specific.
- **Unnecessarily restrictive**: pip refuses `cp312-cp312` wheels on Python 3.13+, even though the binary would work.
- **Wasteful**: forces per-Python-version rebuilds of abi3 crates.

## The fix

In [`Builder.fix_wheel`](src/forge/build.py#L646), keep the existing `pythontag-abitag` part from the upstream WHEEL Tag and swap **only the platform component** with `self.cross_venv.tag`. Fall back to `self.wheel_tag` only when the upstream wheel didn't carry a Tag header.

```python
upstream_tags = wheel_metadata.get_all("Tag", [])
del wheel_metadata["Tag"]
new_tags = []
for tag in upstream_tags:
    py, abi, _platform = tag.rsplit("-", 2)
    new_tags.append(f"{py}-{abi}-{self.cross_venv.tag}")
if not new_tags:
    new_tags = [self.wheel_tag]
for tag in new_tags:
    wheel_metadata["Tag"] = tag
```

### Behavior summary

| Recipe | Upstream Tag | Before this PR | After this PR |
|---|---|---|---|
| cryptography (abi3) | `cp37-abi3-linux_x86_64` | `cp312-cp312-android_24_arm64_v8a` ✗ | `cp37-abi3-android_24_arm64_v8a` ✓ |
| pydantic-core (cp312-specific) | `cp312-cp312-linux_x86_64` | `cp312-cp312-android_24_arm64_v8a` | `cp312-cp312-android_24_arm64_v8a` (unchanged) |
| bcrypt (cp312-specific) | `cp312-cp312-linux_x86_64` | `cp312-cp312-android_24_arm64_v8a` | `cp312-cp312-android_24_arm64_v8a` (unchanged) |

## Test plan

- [ ] Build cryptography for Android arm64 in CI; confirm the produced wheel is named `cryptography-43.0.1-N-cp37-abi3-android_24_arm64_v8a.whl`
- [ ] Build a non-abi3 recipe (e.g. pydantic-core) and confirm the wheel name is unchanged
- [ ] Inspect the produced wheel's `*.dist-info/WHEEL` and confirm the `Tag:` line matches the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)