### PR TITLE
Multi python support (3.12 / 3.13 / 3.14)

### DIFF
--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -201,22 +201,14 @@ jobs:
             # Python 3.14 returns the bogus `/usr/local/...` paths and
             # reports the dep as "not found" (numpy 2.4.6 hits this).
             sudo apt-get install -y sqlite3 pkg-config
-          else
-            # iOS lane: meson's `py.dependency()` and the config-tool
-            # fallback used by `dependency('pybind11')` (in contourpy
-            # etc.) both require a pkg-config binary on PATH before
-            # meson will accept it as the host-machine tool, even when
-            # the .pc file the recipe needs is already in
-            # PKG_CONFIG_PATH. macos-26 happens to ship `pkgconf`
-            # preinstalled (and that formula provides the `pkg-config`
-            # binary), but older / future runner images may not -- so
-            # install only when missing. Guarding the brew call also
-            # silences the "::warning::pkgconf is already installed"
-            # noise that brew otherwise emits unconditionally.
-            if ! command -v pkg-config >/dev/null 2>&1; then
-              brew install pkg-config
-            fi
           fi
+          # iOS lane intentionally does no system-dep install here.
+          # macos-26 already ships pkgconf, which provides the
+          # pkg-config binary meson's `py.dependency()` / config-tool
+          # fallback (used by `dependency('pybind11')` in contourpy
+          # etc.) need on PATH. If a future runner image drops it, the
+          # meson configure step will fail with "Did not find pkg-config
+          # by name 'pkg-config'" and we re-add a guarded install here.
 
           # setup.sh downloads the matching mobile-forge support package for the
           # requested platform and sets MOBILE_FORGE_*_SUPPORT_PATH. When the

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -1,0 +1,419 @@
+name: Build wheels for Python
+
+# Reusable child of build-wheels.yml (the orchestrator). Builds the
+# recipe matrix for one Python version. Called once per Python version
+# from the orchestrator's `build` job; can also be dispatched standalone
+# for single-version debugging without going through the orchestrator's
+# event detection logic.
+
+on:
+  workflow_call:
+    inputs:
+      python_version:
+        description: "Full Python version (e.g. 3.12.13)"
+        required: true
+        type: string
+      archs:
+        description: "Architectures (comma-separated)"
+        required: false
+        type: string
+        default: "android,iOS"
+      packages:
+        description: "Packages (comma-separated, name:version pairs)"
+        required: true
+        type: string
+      prebuild_recipes:
+        description: "Recipes to build first into dist/"
+        required: false
+        type: string
+        default: ""
+      python_build_run_id:
+        description: "flet-dev/python-build run id (overrides release tarball)"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      GEMFURY_TOKEN:
+        required: false
+
+  workflow_dispatch:
+    inputs:
+      python_version:
+        description: "Full Python version (e.g. 3.12.13)"
+        required: true
+        type: choice
+        options:
+          - 3.12.13
+          - 3.13.13
+          - 3.14.5
+        default: 3.12.13
+      archs:
+        description: "Architectures (comma-separated)"
+        required: false
+        default: "android,iOS"
+      packages:
+        description: "Packages (comma-separated)"
+        required: false
+        default: "pydantic-core:,numpy:,pillow:"
+      prebuild_recipes:
+        description: "Prebuild recipes (comma-separated)"
+        required: false
+        default: ""
+      python_build_run_id:
+        description: "flet-dev/python-build run id"
+        required: false
+        default: ""
+
+env:
+  MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"
+  FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile.
+  FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build.
+  FLET_CLI_NO_RICH_OUTPUT: 1
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - id: set-matrix
+        # Matrix is now archs × packages only — the Python axis is
+        # handled by the orchestrator (one child workflow run per
+        # Python version), so this only fans out across what's
+        # specific to this Python.
+        shell: bash
+        run: |
+          ARCHS="${{ inputs.archs }}"
+          PACKAGES="${{ inputs.packages }}"
+          py="${{ inputs.python_version }}"
+          py_short="${py%.*}"   # 3.12.13 -> 3.12 (used in artifact name + python_short field)
+
+          matrix='{"include":['
+          first=true
+          for arch in $(echo "$ARCHS" | tr ',' ' '); do
+            for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
+              pkg_name="${pkg%%:*}"
+              if [[ "$arch" == "android" ]]; then
+                runner="ubuntu-latest"
+                platform="android"
+                rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android,i686-linux-android"
+              else
+                runner="macos-26"
+                platform="ios"
+                rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
+              fi
+              # Read recipe meta (version + build_number + platforms)
+              recipe_version=""; recipe_build=""; declared=""
+              if [[ -f "recipes/$pkg_name/meta.yaml" ]]; then
+                IFS=$'\t' read -r recipe_version recipe_build declared \
+                  <<< "$(uv run --script .ci/read_meta.py "recipes/$pkg_name/meta.yaml")"
+              fi
+
+              # Honor recipe's `package.platforms` on the matrix.
+              if [[ -n "$declared" && ! " $declared " == *" $platform "* ]]; then
+                echo "::notice::Skip ${platform}: ${pkg_name} — recipe declares platforms=[$declared]"
+                continue
+              fi
+
+              # Job display name.
+              pkg_ver_override="${pkg#*:}"
+              display_version="${pkg_ver_override:-$recipe_version}"
+              display_build="${recipe_build:-0}"
+              job_name="${platform}: ${pkg_name} ${display_version} #${display_build}"
+
+              if [ "$first" = true ]; then first=false; else matrix+=','; fi
+              matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"py${py_short}-${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"python_short\":\"$py_short\",\"rust_targets\":\"$rust_targets\"}"
+            done
+          done
+          matrix+=']}'
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: setup
+    name: ${{ matrix.job_name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Free disk space (Ubuntu runners only)
+        if: runner.os == 'Linux'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false      # KEEP — we need android sdk + python tooling
+          android: false         # KEEP — Android SDK is used by Build wheels (NDK) + Test
+          dotnet: true
+          haskell: true
+          large-packages: false  # SKIP — sudo apt remove takes minutes; reaping above is enough
+          docker-images: true
+          swap-storage: true
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust_targets }}
+
+      - name: Install NDK ${{ env.FORGE_NDK_VERSION }} for forge on Android
+        # forge cross-compiles Android wheels with this NDK. The install
+        # script writes NDK_HOME to $GITHUB_ENV so the Build wheels step
+        # (and forge subprocesses) pick it up.
+        if: matrix.platform == 'android'
+        shell: bash
+        run: .ci/install_ndk.sh "$FORGE_NDK_VERSION"
+
+      - name: Build wheels
+        shell: bash
+        env:
+          FORGE_ARCH: ${{ matrix.forge_arch }}
+          FORGE_PACKAGES: ${{ matrix.forge_packages }}
+          PREBUILD_RECIPES: ${{ inputs.prebuild_recipes }}
+          PLATFORM: ${{ matrix.platform }}
+          PYTHON_BUILD_RUN_ID: ${{ inputs.python_build_run_id }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PIP_FIND_LINKS: ${{ github.workspace }}/dist
+          # Per-child-workflow-run Python version. setup.sh consumes
+          # this and pulls the matching python-build support tarball
+          # from flet-dev/python-build/releases/v${minor}.
+          UV_PYTHON: ${{ inputs.python_version }}
+        run: |
+          set -euxo pipefail
+
+          . .ci/common.sh
+
+          if [[ "$PLATFORM" == "android" ]]; then
+            sudo apt-get update
+            # pkg-config is what meson's `py.dependency()` uses to resolve
+            # the Python C dep via the `.pc` files setup.sh relocates.
+            # Without it, meson falls back to sysconfig — which on
+            # Python 3.14 returns the bogus `/usr/local/...` paths and
+            # reports the dep as "not found" (numpy 2.4.6 hits this).
+            sudo apt-get install -y sqlite3 pkg-config
+          fi
+
+          # setup.sh downloads the matching mobile-forge support package for the
+          # requested platform and sets MOBILE_FORGE_*_SUPPORT_PATH. When the
+          # PYTHON_BUILD_RUN_ID env (from inputs above) is set, setup.sh
+          # fetches from that python-build Actions run's artifacts instead of
+          # the canonical v<version> release.
+          source ./setup.sh "$UV_PYTHON" "$PLATFORM"
+
+          # When prebuild_recipes is set, this step builds those recipes FIRST. Their wheels
+          # land in dist/ alongside the consumer wheels. PIP_FIND_LINKS points forge's
+          # host-dep pip resolution at dist/, so the consumer build below picks up the
+          # freshly-built libs over whatever pypi.flet.dev has published.
+          if [[ -n "${PREBUILD_RECIPES:-}" ]]; then
+            for lib in $(echo "$PREBUILD_RECIPES" | tr ',' ' '); do
+              forge "$FORGE_ARCH" "$lib"
+            done
+          fi
+
+          IFS=' ' read -r -a packages <<< "$FORGE_PACKAGES"
+          for package in "${packages[@]}"; do
+            forge "$FORGE_ARCH" "$package"
+          done
+
+          # Drop the support-tree dep wheels produced by make_dep_wheels.py
+          # iOS deps: bzip2, libffi, mpdecimal, openssl, xz
+          # Android deps: bzip2, libffi, openssl, sqlite, xz
+          rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
+
+      # --- Mobile test lane ---------------------------------------------------
+
+      - name: Detect test files for this recipe
+        id: detect-tests
+        shell: bash
+        env:
+          FORGE_PACKAGES: ${{ matrix.forge_packages }}
+          PYTHON_SHORT: ${{ matrix.python_short }}
+        run: |
+          set -euo pipefail
+          pkg_name="${FORGE_PACKAGES%%:*}"
+          pkg_version="${FORGE_PACKAGES#*:}"
+          [[ "$pkg_version" == "$FORGE_PACKAGES" ]] && pkg_version=""
+
+          # Recipe-tester runtime targets Python 3.12 only — `flet build apk`
+          # and the iOS simulator app embed a 3.12 interpreter. Wheels built
+          # for cp313/cp314 are produced and published, but their runtime
+          # tests are skipped here until the Flet runtime catches up.
+          if [[ "$PYTHON_SHORT" != "3.12" ]]; then
+            echo "::notice::Skipping mobile test — recipe-tester runtime is 3.12 only (this entry is py${PYTHON_SHORT})"
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          # Check for the presence of any test files at known locations.
+          elif [[ -d "recipes/$pkg_name/tests" ]] \
+              || [[ -d "recipes/$pkg_name/test" ]] \
+              || compgen -G "recipes/$pkg_name/test_*.py" > /dev/null; then
+            echo "Found tests for $pkg_name"
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "pkg_name=$pkg_name" >> "$GITHUB_OUTPUT"
+            echo "pkg_version=$pkg_version" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Skipping mobile test — no tests/, test/ or test_*.py under recipes/$pkg_name/"
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable KVM
+        # GA'd April 2024 on standard Linux runners; needs a udev rule to grant the runner
+        # user rw on /dev/kvm. Android-only — macOS uses Hypervisor.Framework on its own.
+        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install NDK ${{ env.FLUTTER_NDK_VERSION }} for Flutter Android build
+        # `flet build apk` shells out to Flutter, whose generated Gradle
+        # uses `ndkVersion = flutter.ndkVersion`. Without this NDK
+        # pre-installed at $ANDROID_HOME/ndk/<version>/, Gradle triggers
+        # an auto-install mid-build that flakes intermittently
+        # (InstallFailedException / ZipException). Pre-installing via
+        # the shared install_ndk.sh removes that race.
+        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
+        shell: bash
+        run: .ci/install_ndk.sh "$FLUTTER_NDK_VERSION"
+
+      - name: Stage tests + build recipe-tester APK
+        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
+        shell: bash
+        env:
+          PKG_NAME: ${{ steps.detect-tests.outputs.pkg_name }}
+          PKG_VERSION: ${{ steps.detect-tests.outputs.pkg_version }}
+        run: |
+          set -euxo pipefail
+
+          # Copy just-built wheels into dist-test/ with build tags bumped to
+          # 9999. Reason: pip's resolver merges --find-links and the
+          # --extra-index-url (pypi.flet.dev) and picks the wheel with the
+          # highest build tag per PEP 427. The published wheel on
+          # pypi.flet.dev typically has build tag >= 1, while forge's
+          # freshly-built wheel for the same version may have a lower (or
+          # absent) build tag — so pip silently uses the OLD published wheel
+          # and the recipe fix being validated is bypassed. Bumping local
+          # copies to 9999 guarantees they win. Original dist/ is left
+          # untouched so the publish step still ships at the user-specified
+          # build_number.
+          mkdir -p "$GITHUB_WORKSPACE/dist-test"
+          for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
+              [[ -e "$w" ]] || continue
+              base=$(basename "$w")
+              # name-version[-buildtag]-pytag-abitag-plat.whl
+              # → name-version-9999-pytag-abitag-plat.whl
+              # abitag covers both cp312-cp312 (Python-specific) and
+              # cp37-abi3 (stable ABI, used e.g. by cryptography).
+              new=$(printf '%s\n' "$base" \
+                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-(cp[0-9]+|abi[0-9]+))-/\1-9999-\3-/')
+              cp "$w" "$GITHUB_WORKSPACE/dist-test/$new"
+          done
+
+          ./tests/recipe-tester/stage_recipe.sh "$PKG_NAME" "$PKG_VERSION"
+          cd tests/recipe-tester
+          PIP_FIND_LINKS="$GITHUB_WORKSPACE/dist-test" \
+            uvx --with flet-cli flet build apk --arch x86_64 -vv --yes
+
+      - name: Test on Android emulator (API 28, x86_64)
+        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        timeout-minutes: 20
+        with:
+          # API 28 minimum, NOT 24. mobile-forge wheels target API 24, but
+          # Flet's Android app shell uses ImageDecoder.OnHeaderDecodedListener
+          # (added in API 28) — on a 24 AVD the recipe-tester APK crashes at
+          # launch with ClassNotFoundException before Python ever starts.
+          api-level: 28
+          arch: x86_64
+          target: default
+          disable-animations: true
+          # The reactivecircus action invokes EACH LINE of `script:` through
+          # `sh -c` separately — multi-line constructs (functions, traps, if
+          # blocks) don't survive. Logic lives in .ci/run_android_test.sh
+          # instead, which has its own bash shebang.
+          script: .ci/run_android_test.sh
+
+      # --- iOS lane ----------------------------------------------------------
+
+      - name: Stage tests + build recipe-tester iOS sim app
+        if: matrix.platform == 'ios' && steps.detect-tests.outputs.has_tests == 'true'
+        shell: bash
+        env:
+          PKG_NAME: ${{ steps.detect-tests.outputs.pkg_name }}
+          PKG_VERSION: ${{ steps.detect-tests.outputs.pkg_version }}
+        run: |
+          set -euxo pipefail
+
+          # Same dist-test wheel-bump as the Android lane — pip's build-tag
+          # preference applies equally to iOS-tagged wheels resolving against
+          # pypi.flet.dev's published copies.
+          mkdir -p "$GITHUB_WORKSPACE/dist-test"
+          for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
+              [[ -e "$w" ]] || continue
+              base=$(basename "$w")
+              new=$(printf '%s\n' "$base" \
+                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-(cp[0-9]+|abi[0-9]+))-/\1-9999-\3-/')
+              cp "$w" "$GITHUB_WORKSPACE/dist-test/$new"
+          done
+
+          ./tests/recipe-tester/stage_recipe.sh "$PKG_NAME" "$PKG_VERSION"
+          cd tests/recipe-tester
+          PIP_FIND_LINKS="$GITHUB_WORKSPACE/dist-test" \
+            uvx --with flet-cli flet build ios-simulator -v --yes
+
+      - name: Test on iOS Simulator
+        if: matrix.platform == 'ios' && steps.detect-tests.outputs.has_tests == 'true'
+        timeout-minutes: 25
+        shell: bash
+        # iOS sim cold-boot can take 1-4 min on the macos-26 image.
+        run: .ci/run_ios_test.sh
+
+      # --- /iOS lane ---------------------------------------------------------
+
+      - name: Upload test artifacts
+        if: always() && steps.detect-tests.outputs.has_tests == 'true'
+        uses: actions/upload-artifact@v6
+        with:
+          name: test-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            console.log
+            logcat-on-failure.txt
+            screen-on-failure.png
+            syslog-on-failure.txt
+          if-no-files-found: ignore
+          retention-days: 90
+
+      # --- /Mobile test lane ------------------------------------------------
+
+      - name: Publish wheels
+        if: ${{ success() && hashFiles('dist/*.whl') != '' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.python_build_run_id == '' }}
+        shell: bash
+        env:
+          GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
+        run: |
+          set -euxo pipefail
+          . .ci/common.sh
+          publish_to_pypi dist/*.whl
+
+      - name: Upload logs on success
+        if: ${{ success() && hashFiles('logs/*.log') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: logs-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: logs/*.log
+
+      - name: Upload errors on failure
+        if: ${{ failure() && hashFiles('errors/*.log') != '' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: errors-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: errors/*.log

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -1,4 +1,4 @@
-name: Build wheels for Python
+name: Build wheels for Python version
 
 # Reusable child of build-wheels.yml (the orchestrator). Builds the
 # recipe matrix for one Python version. Called once per Python version
@@ -125,7 +125,7 @@ jobs:
               pkg_ver_override="${pkg#*:}"
               display_version="${pkg_ver_override:-$recipe_version}"
               display_build="${recipe_build:-0}"
-              job_name="${platform}: ${pkg_name} ${display_version} #${display_build}"
+              job_name="${pkg_name} ${display_version} (${platform}) #${display_build}"
 
               if [ "$first" = true ]; then first=false; else matrix+=','; fi
               matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"py${py_short}-${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"python_short\":\"$py_short\",\"rust_targets\":\"$rust_targets\"}"

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -201,6 +201,15 @@ jobs:
             # Python 3.14 returns the bogus `/usr/local/...` paths and
             # reports the dep as "not found" (numpy 2.4.6 hits this).
             sudo apt-get install -y sqlite3 pkg-config
+          else
+            # iOS lane runs on macos-26 which doesn't ship pkg-config.
+            # Same rationale as Android: meson's `py.dependency()` and the
+            # config-tool fallback used by `dependency('pybind11')` (in
+            # contourpy etc.) both require a pkg-config binary on PATH
+            # before meson will accept it as the host-machine tool, even
+            # when the .pc file the recipe needs is already in
+            # PKG_CONFIG_PATH.
+            brew install pkg-config
           fi
 
           # setup.sh downloads the matching mobile-forge support package for the

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -277,12 +277,10 @@ jobs:
           for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
               [[ -e "$w" ]] || continue
               base=$(basename "$w")
-              # name-version[-buildtag]-pytag-abitag-plat.whl
-              # → name-version-9999-pytag-abitag-plat.whl
-              # abitag covers both cp312-cp312 (Python-specific) and
-              # cp37-abi3 (stable ABI, used e.g. by cryptography).
+              # name-version[-buildtag]-cpXY-cpXY-plat.whl
+              # → name-version-9999-cpXY-cpXY-plat.whl
               new=$(printf '%s\n' "$base" \
-                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-(cp[0-9]+|abi[0-9]+))-/\1-9999-\3-/')
+                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-cp[0-9]+)-/\1-9999-\3-/')
               cp "$w" "$GITHUB_WORKSPACE/dist-test/$new"
           done
 
@@ -296,18 +294,13 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         timeout-minutes: 20
         with:
-          # API 28 minimum, NOT 24. mobile-forge wheels target API 24, but
-          # Flet's Android app shell uses ImageDecoder.OnHeaderDecodedListener
-          # (added in API 28) — on a 24 AVD the recipe-tester APK crashes at
-          # launch with ClassNotFoundException before Python ever starts.
+          # API 28 minimum, NOT 24. mobile-forge wheels target API 24, but Flet's Android app shell
+          # uses ImageDecoder.OnHeaderDecodedListener (added in API 28) — on a 24 AVD the recipe-tester
+          # APK crashes at launch with ClassNotFoundException before Python ever starts.
           api-level: 28
           arch: x86_64
           target: default
           disable-animations: true
-          # The reactivecircus action invokes EACH LINE of `script:` through
-          # `sh -c` separately — multi-line constructs (functions, traps, if
-          # blocks) don't survive. Logic lives in .ci/run_android_test.sh
-          # instead, which has its own bash shebang.
           script: .ci/run_android_test.sh
 
       # --- iOS lane ----------------------------------------------------------

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -83,10 +83,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
 
       - id: set-matrix
-        # Matrix is now archs × packages only — the Python axis is
-        # handled by the orchestrator (one child workflow run per
-        # Python version), so this only fans out across what's
-        # specific to this Python.
         shell: bash
         run: |
           ARCHS="${{ inputs.archs }}"
@@ -125,7 +121,7 @@ jobs:
               pkg_ver_override="${pkg#*:}"
               display_version="${pkg_ver_override:-$recipe_version}"
               display_build="${recipe_build:-0}"
-              job_name="${pkg_name} ${display_version} (${platform}) #${display_build}"
+              job_name="${pkg_name} ${display_version} #${display_build} (${platform})"
 
               if [ "$first" = true ]; then first=false; else matrix+=','; fi
               matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"py${py_short}-${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"python_short\":\"$py_short\",\"rust_targets\":\"$rust_targets\"}"
@@ -167,9 +163,8 @@ jobs:
           targets: ${{ matrix.rust_targets }}
 
       - name: Install NDK ${{ env.FORGE_NDK_VERSION }} for forge on Android
-        # forge cross-compiles Android wheels with this NDK. The install
-        # script writes NDK_HOME to $GITHUB_ENV so the Build wheels step
-        # (and forge subprocesses) pick it up.
+        # forge cross-compiles Android wheels with this NDK. The install script writes NDK_HOME
+        # to $GITHUB_ENV so the Build wheels step (and forge subprocesses) pick it up.
         if: matrix.platform == 'android'
         shell: bash
         run: .ci/install_ndk.sh "$FORGE_NDK_VERSION"
@@ -184,9 +179,6 @@ jobs:
           PYTHON_BUILD_RUN_ID: ${{ inputs.python_build_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PIP_FIND_LINKS: ${{ github.workspace }}/dist
-          # Per-child-workflow-run Python version. setup.sh consumes
-          # this and pulls the matching python-build support tarball
-          # from flet-dev/python-build/releases/v${minor}.
           UV_PYTHON: ${{ inputs.python_version }}
         run: |
           set -euxo pipefail
@@ -195,26 +187,13 @@ jobs:
 
           if [[ "$PLATFORM" == "android" ]]; then
             sudo apt-get update
-            # pkg-config is what meson's `py.dependency()` uses to resolve
-            # the Python C dep via the `.pc` files setup.sh relocates.
-            # Without it, meson falls back to sysconfig — which on
-            # Python 3.14 returns the bogus `/usr/local/...` paths and
-            # reports the dep as "not found" (numpy 2.4.6 hits this).
+            # pkg-config is what meson's `py.dependency()` uses to resolve the Python C dep via
+            # the `.pc` files setup.sh relocates. Without it, meson falls back to sysconfig — which on
+            # Python 3.14 returns the bogus `/usr/local/...` paths and reports the dep as "not found".
             sudo apt-get install -y sqlite3 pkg-config
           fi
-          # iOS lane intentionally does no system-dep install here.
-          # macos-26 already ships pkgconf, which provides the
-          # pkg-config binary meson's `py.dependency()` / config-tool
-          # fallback (used by `dependency('pybind11')` in contourpy
-          # etc.) need on PATH. If a future runner image drops it, the
-          # meson configure step will fail with "Did not find pkg-config
-          # by name 'pkg-config'" and we re-add a guarded install here.
 
-          # setup.sh downloads the matching mobile-forge support package for the
-          # requested platform and sets MOBILE_FORGE_*_SUPPORT_PATH. When the
-          # PYTHON_BUILD_RUN_ID env (from inputs above) is set, setup.sh
-          # fetches from that python-build Actions run's artifacts instead of
-          # the canonical v<version> release.
+          # Downloads the matching mobile-forge support package for the requested platform.
           source ./setup.sh "$UV_PYTHON" "$PLATFORM"
 
           # When prebuild_recipes is set, this step builds those recipes FIRST. Their wheels
@@ -236,8 +215,6 @@ jobs:
           # iOS deps: bzip2, libffi, mpdecimal, openssl, xz
           # Android deps: bzip2, libffi, openssl, sqlite, xz
           rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
-
-      # --- Mobile test lane ---------------------------------------------------
 
       - name: Detect test files for this recipe
         id: detect-tests
@@ -275,12 +252,6 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Install NDK ${{ env.FLUTTER_NDK_VERSION }} for Flutter Android build
-        # `flet build apk` shells out to Flutter, whose generated Gradle
-        # uses `ndkVersion = flutter.ndkVersion`. Without this NDK
-        # pre-installed at $ANDROID_HOME/ndk/<version>/, Gradle triggers
-        # an auto-install mid-build that flakes intermittently
-        # (InstallFailedException / ZipException). Pre-installing via
-        # the shared install_ndk.sh removes that race.
         if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
         shell: bash
         run: .ci/install_ndk.sh "$FLUTTER_NDK_VERSION"
@@ -294,17 +265,14 @@ jobs:
         run: |
           set -euxo pipefail
 
-          # Copy just-built wheels into dist-test/ with build tags bumped to
-          # 9999. Reason: pip's resolver merges --find-links and the
-          # --extra-index-url (pypi.flet.dev) and picks the wheel with the
-          # highest build tag per PEP 427. The published wheel on
-          # pypi.flet.dev typically has build tag >= 1, while forge's
-          # freshly-built wheel for the same version may have a lower (or
-          # absent) build tag — so pip silently uses the OLD published wheel
-          # and the recipe fix being validated is bypassed. Bumping local
-          # copies to 9999 guarantees they win. Original dist/ is left
-          # untouched so the publish step still ships at the user-specified
-          # build_number.
+          # Copy just-built wheels into dist-test/ with build tags bumped to 9999. 
+          # Reason: pip's resolver merges --find-links and the --extra-index-url (pypi.flet.dev)
+          # and picks the wheel with the highest build tag per PEP 427. The published wheel on
+          # pypi.flet.dev typically has build tag >= 1, while forge's freshly-built wheel for 
+          # the same version may have a lower (or absent) build tag — so pip silently uses the OLD 
+          # published wheel and the recipe fix being validated is bypassed. Bumping local copies to 
+          # 9999 guarantees they win. Original dist/ is left untouched so the publish step still ships 
+          # at the user-specified build_number.
           mkdir -p "$GITHUB_WORKSPACE/dist-test"
           for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
               [[ -e "$w" ]] || continue

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -253,15 +253,8 @@ jobs:
           pkg_version="${FORGE_PACKAGES#*:}"
           [[ "$pkg_version" == "$FORGE_PACKAGES" ]] && pkg_version=""
 
-          # Recipe-tester runtime targets Python 3.12 only — `flet build apk`
-          # and the iOS simulator app embed a 3.12 interpreter. Wheels built
-          # for cp313/cp314 are produced and published, but their runtime
-          # tests are skipped here until the Flet runtime catches up.
-          if [[ "$PYTHON_SHORT" != "3.12" ]]; then
-            echo "::notice::Skipping mobile test — recipe-tester runtime is 3.12 only (this entry is py${PYTHON_SHORT})"
-            echo "has_tests=false" >> "$GITHUB_OUTPUT"
           # Check for the presence of any test files at known locations.
-          elif [[ -d "recipes/$pkg_name/tests" ]] \
+          if [[ -d "recipes/$pkg_name/tests" ]] \
               || [[ -d "recipes/$pkg_name/test" ]] \
               || compgen -G "recipes/$pkg_name/test_*.py" > /dev/null; then
             echo "Found tests for $pkg_name"

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -202,14 +202,20 @@ jobs:
             # reports the dep as "not found" (numpy 2.4.6 hits this).
             sudo apt-get install -y sqlite3 pkg-config
           else
-            # iOS lane runs on macos-26 which doesn't ship pkg-config.
-            # Same rationale as Android: meson's `py.dependency()` and the
-            # config-tool fallback used by `dependency('pybind11')` (in
-            # contourpy etc.) both require a pkg-config binary on PATH
-            # before meson will accept it as the host-machine tool, even
-            # when the .pc file the recipe needs is already in
-            # PKG_CONFIG_PATH.
-            brew install pkg-config
+            # iOS lane: meson's `py.dependency()` and the config-tool
+            # fallback used by `dependency('pybind11')` (in contourpy
+            # etc.) both require a pkg-config binary on PATH before
+            # meson will accept it as the host-machine tool, even when
+            # the .pc file the recipe needs is already in
+            # PKG_CONFIG_PATH. macos-26 happens to ship `pkgconf`
+            # preinstalled (and that formula provides the `pkg-config`
+            # binary), but older / future runner images may not -- so
+            # install only when missing. Guarding the brew call also
+            # silences the "::warning::pkgconf is already installed"
+            # noise that brew otherwise emits unconditionally.
+            if ! command -v pkg-config >/dev/null 2>&1; then
+              brew install pkg-config
+            fi
           fi
 
           # setup.sh downloads the matching mobile-forge support package for the

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -1,16 +1,12 @@
-name: Build wheels for Python version
+name: Build and Publish wheels for Python version
 
-# Reusable child of build-wheels.yml (the orchestrator). Builds the
-# recipe matrix for one Python version. Called once per Python version
-# from the orchestrator's `build` job; can also be dispatched standalone
-# for single-version debugging without going through the orchestrator's
-# event detection logic.
+# Reusable child of build-wheels.yml (the orchestrator). Builds the recipe matrix for one Python version.
 
 on:
   workflow_call:
     inputs:
       python_version:
-        description: "Full Python version (e.g. 3.12.13)"
+        description: "Python version"
         required: true
         type: string
       archs:
@@ -27,6 +23,13 @@ on:
         required: false
         type: string
         default: ""
+      mobile_test_pythons:
+        description: |
+          Comma-separated full python versions whose mobile tests should run (or "ALL").
+          Other python versions still build wheels but skip the APK / iOS-simulator stage.
+        required: false
+        type: string
+        default: "3.12.13"
       python_build_run_id:
         description: "flet-dev/python-build run id (overrides release tarball)"
         required: false
@@ -39,7 +42,7 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        description: "Full Python version (e.g. 3.12.13)"
+        description: "Python version"
         required: true
         type: choice
         options:
@@ -59,6 +62,13 @@ on:
         description: "Prebuild recipes (comma-separated)"
         required: false
         default: ""
+      mobile_test_pythons:
+        description: |
+          Comma-separated full python versions whose mobile tests
+          should run (or "ALL"). Other python versions still build
+          wheels but skip the APK / iOS-simulator stage.
+        required: false
+        default: "3.12.13"
       python_build_run_id:
         description: "flet-dev/python-build run id"
         required: false
@@ -88,7 +98,7 @@ jobs:
           ARCHS="${{ inputs.archs }}"
           PACKAGES="${{ inputs.packages }}"
           py="${{ inputs.python_version }}"
-          py_short="${py%.*}"   # 3.12.13 -> 3.12 (used in artifact name + python_short field)
+          py_short="${py%.*}"   # 3.12.13 -> 3.12
 
           matrix='{"include":['
           first=true
@@ -163,8 +173,6 @@ jobs:
           targets: ${{ matrix.rust_targets }}
 
       - name: Install NDK ${{ env.FORGE_NDK_VERSION }} for forge on Android
-        # forge cross-compiles Android wheels with this NDK. The install script writes NDK_HOME
-        # to $GITHUB_ENV so the Build wheels step (and forge subprocesses) pick it up.
         if: matrix.platform == 'android'
         shell: bash
         run: .ci/install_ndk.sh "$FORGE_NDK_VERSION"
@@ -216,17 +224,32 @@ jobs:
           # Android deps: bzip2, libffi, openssl, sqlite, xz
           rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
 
-      - name: Detect test files for this recipe
+      - name: Detect test files
         id: detect-tests
         shell: bash
         env:
           FORGE_PACKAGES: ${{ matrix.forge_packages }}
           PYTHON_SHORT: ${{ matrix.python_short }}
+          MOBILE_TEST_PYTHONS: ${{ inputs.mobile_test_pythons }}
         run: |
           set -euo pipefail
           pkg_name="${FORGE_PACKAGES%%:*}"
           pkg_version="${FORGE_PACKAGES#*:}"
           [[ "$pkg_version" == "$FORGE_PACKAGES" ]] && pkg_version=""
+
+          # Gate on the caller-provided mobile_test_pythons list: only Python 
+          # versions in that list actually run the APK/iOS-sim test step.
+          if [[ "$MOBILE_TEST_PYTHONS" != "ALL" ]]; then
+            allowed=""
+            for v in $(echo "$MOBILE_TEST_PYTHONS" | tr ',' ' '); do
+              allowed="${allowed:+$allowed }${v%.*}"
+            done
+            if [[ ! " $allowed " == *" $PYTHON_SHORT "* ]]; then
+              echo "::notice::Skipping mobile test — py${PYTHON_SHORT} not in mobile_test_pythons=${MOBILE_TEST_PYTHONS}"
+              echo "has_tests=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
 
           # Check for the presence of any test files at known locations.
           if [[ -d "recipes/$pkg_name/tests" ]] \
@@ -237,7 +260,7 @@ jobs:
             echo "pkg_name=$pkg_name" >> "$GITHUB_OUTPUT"
             echo "pkg_version=$pkg_version" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::Skipping mobile test — no tests/, test/ or test_*.py under recipes/$pkg_name/"
+            echo "::notice::Skipping mobile test — no tests/ under recipes/$pkg_name/"
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -303,8 +326,6 @@ jobs:
           disable-animations: true
           script: .ci/run_android_test.sh
 
-      # --- iOS lane ----------------------------------------------------------
-
       - name: Stage tests + build recipe-tester iOS sim app
         if: matrix.platform == 'ios' && steps.detect-tests.outputs.has_tests == 'true'
         shell: bash
@@ -338,8 +359,6 @@ jobs:
         # iOS sim cold-boot can take 1-4 min on the macos-26 image.
         run: .ci/run_ios_test.sh
 
-      # --- /iOS lane ---------------------------------------------------------
-
       - name: Upload test artifacts
         if: always() && steps.detect-tests.outputs.has_tests == 'true'
         uses: actions/upload-artifact@v6
@@ -352,8 +371,6 @@ jobs:
             syslog-on-failure.txt
           if-no-files-found: ignore
           retention-days: 90
-
-      # --- /Mobile test lane ------------------------------------------------
 
       - name: Publish wheels
         if: ${{ success() && hashFiles('dist/*.whl') != '' && github.event_name == 'push' && github.ref == 'refs/heads/main' && inputs.python_build_run_id == '' }}

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -1,37 +1,43 @@
 name: Build and Publish wheels for Python version
 
-# Reusable child of build-wheels.yml (the orchestrator). Builds the recipe matrix for one Python version.
-
 on:
   workflow_call:
     inputs:
       python_version:
-        description: "Python version"
+        description: |
+          Python version:
         required: true
         type: string
       archs:
-        description: "Architectures (comma-separated)"
+        description: |
+          Architectures (comma-separated):
         required: false
         type: string
         default: "android,iOS"
       packages:
-        description: "Packages (comma-separated, name:version pairs)"
+        description: |
+          Packages (comma-separated) or 'ALL' to select all available recipes:
         required: true
         type: string
       prebuild_recipes:
-        description: "Recipes to build first into dist/"
+        description: |
+          Recipes (comma-separated; typically flet-lib*) to build FIRST and seed into 
+          the matrix's dist/ for host-dep pip resolution (e.g. flet-libgdal -> gdal):
         required: false
         type: string
         default: ""
       mobile_test_pythons:
         description: |
-          Comma-separated full python versions whose mobile tests should run (or "ALL").
-          Other python versions still build wheels but skip the APK / iOS-simulator stage.
+          Python versions (comma-separated) whose recipe mobile tests should actually run.
+          Versions in `python_versions` that aren't in this list still build wheels but skip the
+          APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
         type: string
         default: "3.12.13"
       python_build_run_id:
-        description: "flet-dev/python-build run id (overrides release tarball)"
+        description: |
+          flet-dev/python-build Actions run-id whose artifacts to use as the
+          python-build support tree, instead of the v<version> release tarball:
         required: false
         type: string
         default: ""
@@ -42,7 +48,8 @@ on:
   workflow_dispatch:
     inputs:
       python_version:
-        description: "Python version"
+        description: |
+          Python version:
         required: true
         type: choice
         options:
@@ -51,33 +58,39 @@ on:
           - 3.14.5
         default: 3.12.13
       archs:
-        description: "Architectures (comma-separated)"
+        description: |
+          Architectures (comma-separated):
         required: false
         default: "android,iOS"
       packages:
-        description: "Packages (comma-separated)"
+        description: |
+          Packages (comma-separated) or 'ALL' to select all available recipes:
         required: false
         default: "pydantic-core:,numpy:,pillow:"
       prebuild_recipes:
-        description: "Prebuild recipes (comma-separated)"
+        description: |
+          Recipes (comma-separated; typically flet-lib*) to build FIRST and seed into 
+          the matrix's dist/ for host-dep pip resolution (e.g. flet-libgdal -> gdal):
         required: false
         default: ""
       mobile_test_pythons:
         description: |
-          Comma-separated full python versions whose mobile tests
-          should run (or "ALL"). Other python versions still build
-          wheels but skip the APK / iOS-simulator stage.
+          Python versions (comma-separated) whose recipe mobile tests should actually run.
+          Versions in `python_versions` that aren't in this list still build wheels but skip the
+          APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
         default: "3.12.13"
       python_build_run_id:
-        description: "flet-dev/python-build run id"
+        description: |
+          flet-dev/python-build Actions run-id whose artifacts to use as the
+          python-build support tree, instead of the v<version> release tarball:
         required: false
         default: ""
 
 env:
-  MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"
-  FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile.
-  FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build.
+  FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile
+  FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build
+  MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"  # disable caching - guards against poisoned-cache failures
   FLET_CLI_NO_RICH_OUTPUT: 1
 
 jobs:
@@ -114,6 +127,7 @@ jobs:
                 platform="ios"
                 rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
               fi
+          
               # Read recipe meta (version + build_number + platforms)
               recipe_version=""; recipe_build=""; declared=""
               if [[ -f "recipes/$pkg_name/meta.yaml" ]]; then
@@ -121,7 +135,7 @@ jobs:
                   <<< "$(uv run --script .ci/read_meta.py "recipes/$pkg_name/meta.yaml")"
               fi
 
-              # Honor recipe's `package.platforms` on the matrix.
+              # Honor recipe's declared `platforms` on the matrix.
               if [[ -n "$declared" && ! " $declared " == *" $platform "* ]]; then
                 echo "::notice::Skip ${platform}: ${pkg_name} — recipe declares platforms=[$declared]"
                 continue
@@ -152,7 +166,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Free disk space (Ubuntu runners only)
+      - name: Free disk space
         if: runner.os == 'Linux'
         uses: jlumbroso/free-disk-space@main
         with:
@@ -201,7 +215,7 @@ jobs:
             sudo apt-get install -y sqlite3 pkg-config
           fi
 
-          # Downloads the matching mobile-forge support package for the requested platform.
+          # Sets up and downloads the matching mobile-forge support package for the requested platform.
           source ./setup.sh "$UV_PYTHON" "$PLATFORM"
 
           # When prebuild_recipes is set, this step builds those recipes FIRST. Their wheels

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -34,36 +34,60 @@ on:
         required: false
         default: ""
 
+  # Reusable-workflow entry point for cross-repo callers.
+  workflow_call:
+    inputs:
+      archs:
+        type: string
+        required: false
+        default: "android,iOS"
+      packages:
+        type: string
+        required: false
+        default: "pydantic-core:,numpy:,pillow:"
+      prebuild_recipes:
+        type: string
+        required: false
+        default: ""
+      python_versions:
+        type: string
+        required: false
+        default: "3.12.13,3.13.13,3.14.5"
+      python_build_run_id:
+        type: string
+        required: false
+        default: ""
+    secrets:
+      GEMFURY_TOKEN:
+        required: false
+
 # Cancel in-flight runs when a newer event arrives for the same logical branch.
-# Disabled during the multi-python rollout — each push should leave a full
-# CI trail so we can see how each Python version's matrix behaves.
 # concurrency:
 #   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
 #   cancel-in-progress: true
 
 env:
-  # Default Python sets selected by the setup job's detect-pythons step.
+  # Default Python sets selected by the detect job's detect-pythons step.
   # PUBLISH = used on push-to-main (we ship cp312/cp313/cp314 wheels).
   # DEV     = used on every other event (faster iteration; manual dispatch
   #           can override via the `python_versions` input).
   DEFAULT_PYTHONS_PUBLISH: "3.12.13,3.13.13,3.14.5"
   DEFAULT_PYTHONS_DEV:     "3.12.13,3.13.13,3.14.5"
-  MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"
-  FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile.
-  FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build.
-  FLET_CLI_NO_RICH_OUTPUT: 1
 
 jobs:
-  setup:
+  # Single coordination job: decides which Python versions and which
+  # recipe set this run covers, then hands both off to one child workflow
+  # run per Python version. The child (build-wheels-version.yml) is
+  # responsible for the per-recipe matrix and the build/test/publish
+  # steps.
+  detect:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      pythons_json: ${{ steps.detect-pythons.outputs.pythons_json }}
+      packages: ${{ steps.detect-packages.outputs.packages }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v7
 
       - name: Get changed recipes
         id: changed-recipes
@@ -77,7 +101,8 @@ jobs:
         # Decide which Python versions this run fans out across. Workflow
         # input wins; otherwise: push to main publishes the full PUBLISH
         # set (cp312/cp313/cp314), every other trigger uses DEV (just
-        # cp312) for iteration speed.
+        # cp312) for iteration speed. Emits a JSON array consumed by the
+        # build job's `strategy.matrix.python_version`.
         shell: bash
         env:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
@@ -91,8 +116,17 @@ jobs:
           else
             pythons="$DEFAULT_PYTHONS_DEV"
           fi
-          echo "Detected pythons: $pythons"
-          echo "pythons=$pythons" >> "$GITHUB_OUTPUT"
+          
+          # Hand-built JSON array — no jq dep needed.
+          json="["
+          first=true
+          for py in $(echo "$pythons" | tr ',' ' '); do
+            if [ "$first" = true ]; then first=false; else json+=","; fi
+            json+="\"$py\""
+          done
+          json+="]"
+          echo "Detected pythons: $pythons -> $json"
+          echo "pythons_json=$json" >> "$GITHUB_OUTPUT"
 
       - id: detect-packages
         shell: bash
@@ -102,7 +136,7 @@ jobs:
           CHANGED_DIRS: ${{ steps.changed-recipes.outputs.all_changed_files }}
         run: |
           SMOKE_TEST="pydantic-core:,numpy:,pillow:"
-          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_call" ]]; then
             # The literal value "ALL" expands to every recipe with a meta.yaml under recipes/.
             if [[ "$INPUT_PACKAGES" == "ALL" ]]; then
               pkgs=""
@@ -126,341 +160,19 @@ jobs:
           echo "Detected packages: $pkgs"
           echo "packages=$pkgs" >> "$GITHUB_OUTPUT"
 
-      - id: set-matrix
-        shell: bash
-        run: |
-          ARCHS="${{ inputs.archs || 'android,iOS' }}"
-          PYTHONS="${{ steps.detect-pythons.outputs.pythons }}"
-          PACKAGES="${{ steps.detect-packages.outputs.packages }}"
-
-          matrix='{"include":['
-          first=true
-          for arch in $(echo "$ARCHS" | tr ',' ' '); do
-            for py in $(echo "$PYTHONS" | tr ',' ' '); do
-              py_short="${py%.*}"   # 3.12.13 -> 3.12 (display + tag prefix)
-              for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
-                pkg_name="${pkg%%:*}"
-                if [[ "$arch" == "android" ]]; then
-                  runner="ubuntu-latest"
-                  platform="android"
-                  rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android,i686-linux-android"
-                else
-                  runner="macos-26"
-                  platform="ios"
-                  rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
-                fi
-                # Read recipe meta (version + build_number + platforms)
-                recipe_version=""; recipe_build=""; declared=""
-                if [[ -f "recipes/$pkg_name/meta.yaml" ]]; then
-                  IFS=$'\t' read -r recipe_version recipe_build declared \
-                    <<< "$(uv run --script .ci/read_meta.py "recipes/$pkg_name/meta.yaml")"
-                fi
-
-                # Honor recipe's `package.platforms` on the matrix.
-                if [[ -n "$declared" && ! " $declared " == *" $platform "* ]]; then
-                  echo "::notice::Skip py${py_short} ${platform}: ${pkg_name} — recipe declares platforms=[$declared]"
-                  continue
-                fi
-
-                # Compose the job display name. The build number comes from
-                # the recipe's meta.yaml (read above): #59 dropped the
-                # build_number workflow input, so meta.yaml is the source of
-                # truth.
-                pkg_ver_override="${pkg#*:}"
-                display_version="${pkg_ver_override:-$recipe_version}"
-                display_build="${recipe_build:-0}"
-                job_name="py${py_short} ${platform}: ${pkg_name} ${display_version} #${display_build}"
-
-                if [ "$first" = true ]; then first=false; else matrix+=','; fi
-                matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"py${py_short}-${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"python_version\":\"$py\",\"python_short\":\"$py_short\",\"rust_targets\":\"$rust_targets\"}"
-              done
-            done
-          done
-          matrix+=']}'
-          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
-
+  # One child workflow run per Python version.
   build:
-    needs: setup
-    name: ${{ matrix.job_name }}
-    runs-on: ${{ matrix.runner }}
+    name: Python ${{ matrix.python_version }}
+    needs: detect
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-
-      - name: Free disk space (Ubuntu runners only)
-        if: runner.os == 'Linux'
-        uses: jlumbroso/free-disk-space@main
-        with:
-          tool-cache: false      # KEEP — we need android sdk + python tooling
-          android: false         # KEEP — Android SDK is used by Build wheels (NDK) + Test
-          dotnet: true
-          haskell: true
-          large-packages: false  # SKIP — sudo apt remove takes minutes; reaping above is enough
-          docker-images: true
-          swap-storage: true
-
-      - name: Setup uv
-        uses: astral-sh/setup-uv@v7
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.rust_targets }}
-
-      - name: Install NDK ${{ env.FORGE_NDK_VERSION }} for forge on Android
-        # forge cross-compiles Android wheels with this NDK. The install
-        # script writes NDK_HOME to $GITHUB_ENV so the Build wheels step
-        # (and forge subprocesses) pick it up.
-        if: matrix.platform == 'android'
-        shell: bash
-        run: .ci/install_ndk.sh "$FORGE_NDK_VERSION"
-
-      - name: Build wheels
-        shell: bash
-        env:
-          FORGE_ARCH: ${{ matrix.forge_arch }}
-          FORGE_PACKAGES: ${{ matrix.forge_packages }}
-          PREBUILD_RECIPES: ${{ inputs.prebuild_recipes }}
-          PLATFORM: ${{ matrix.platform }}
-          PYTHON_BUILD_RUN_ID: ${{ inputs.python_build_run_id }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PIP_FIND_LINKS: ${{ github.workspace }}/dist
-          # Pinned per matrix entry by detect-pythons + set-matrix (e.g. 3.13.13).
-          # setup.sh consumes this and pulls the matching python-build support
-          # tarball from flet-dev/python-build/releases/v${minor}.
-          UV_PYTHON: ${{ matrix.python_version }}
-        run: |
-          set -euxo pipefail
-
-          . .ci/common.sh
-
-          if [[ "$PLATFORM" == "android" ]]; then
-            sudo apt-get update
-            # pkg-config is what meson's `py.dependency()` uses to resolve
-            # the Python C dep via the `.pc` files setup.sh relocates.
-            # Without it, meson falls back to sysconfig — which on
-            # Python 3.14 returns the bogus `/usr/local/...` paths and
-            # reports the dep as "not found" (numpy 2.4.6 hits this).
-            sudo apt-get install -y sqlite3 pkg-config
-          fi
-
-          # setup.sh downloads the matching mobile-forge support package for the
-          # requested platform and sets MOBILE_FORGE_*_SUPPORT_PATH. When the
-          # PYTHON_BUILD_RUN_ID env (from inputs above) is set, setup.sh
-          # fetches from that python-build Actions run's artifacts instead of
-          # the canonical v<version> release.
-          source ./setup.sh "$UV_PYTHON" "$PLATFORM"
-
-          # When prebuild_recipes is set, this step builds those recipes FIRST. Their wheels
-          # land in dist/ alongside the consumer wheels. PIP_FIND_LINKS points forge's
-          # host-dep pip resolution at dist/, so the consumer build below picks up the
-          # freshly-built libs over whatever pypi.flet.dev has published.
-          if [[ -n "${PREBUILD_RECIPES:-}" ]]; then
-            for lib in $(echo "$PREBUILD_RECIPES" | tr ',' ' '); do
-              forge "$FORGE_ARCH" "$lib"
-            done
-          fi
-
-          IFS=' ' read -r -a packages <<< "$FORGE_PACKAGES"
-          for package in "${packages[@]}"; do
-            forge "$FORGE_ARCH" "$package"
-          done
-
-          # Drop the support-tree dep wheels produced by make_dep_wheels.py
-          # iOS deps: bzip2, libffi, mpdecimal, openssl, xz
-          # Android deps: bzip2, libffi, openssl, sqlite, xz
-          rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
-
-      # --- Mobile test lane ---------------------------------------------------
-
-      - name: Detect test files for this recipe
-        id: detect-tests
-        shell: bash
-        env:
-          FORGE_PACKAGES: ${{ matrix.forge_packages }}
-          PYTHON_SHORT: ${{ matrix.python_short }}
-        run: |
-          set -euo pipefail
-          pkg_name="${FORGE_PACKAGES%%:*}"
-          pkg_version="${FORGE_PACKAGES#*:}"
-          [[ "$pkg_version" == "$FORGE_PACKAGES" ]] && pkg_version=""
-
-          # Recipe-tester runtime targets Python 3.12 only — `flet build apk`
-          # and the iOS simulator app embed a 3.12 interpreter. Wheels built
-          # for cp313/cp314 are produced and published, but their runtime
-          # tests are skipped here until the Flet runtime catches up.
-          if [[ "$PYTHON_SHORT" != "3.12" ]]; then
-            echo "::notice::Skipping mobile test — recipe-tester runtime is 3.12 only (this entry is py${PYTHON_SHORT})"
-            echo "has_tests=false" >> "$GITHUB_OUTPUT"
-          # Check for the presence of any test files at known locations.
-          elif [[ -d "recipes/$pkg_name/tests" ]] \
-              || [[ -d "recipes/$pkg_name/test" ]] \
-              || compgen -G "recipes/$pkg_name/test_*.py" > /dev/null; then
-            echo "Found tests for $pkg_name"
-            echo "has_tests=true" >> "$GITHUB_OUTPUT"
-            echo "pkg_name=$pkg_name" >> "$GITHUB_OUTPUT"
-            echo "pkg_version=$pkg_version" >> "$GITHUB_OUTPUT"
-          else
-            echo "::notice::Skipping mobile test — no tests/, test/ or test_*.py under recipes/$pkg_name/"
-            echo "has_tests=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Enable KVM
-        # GA'd April 2024 on standard Linux runners; needs a udev rule to grant the runner
-        # user rw on /dev/kvm. Android-only — macOS uses Hypervisor.Framework on its own.
-        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
-            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-
-      - name: Install NDK ${{ env.FLUTTER_NDK_VERSION }} for Flutter Android build
-        # `flet build apk` shells out to Flutter, whose generated Gradle
-        # uses `ndkVersion = flutter.ndkVersion`. Without this NDK
-        # pre-installed at $ANDROID_HOME/ndk/<version>/, Gradle triggers
-        # an auto-install mid-build that flakes intermittently
-        # (InstallFailedException / ZipException). Pre-installing via
-        # the shared install_ndk.sh removes that race.
-        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
-        shell: bash
-        run: .ci/install_ndk.sh "$FLUTTER_NDK_VERSION"
-
-      - name: Stage tests + build recipe-tester APK
-        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
-        shell: bash
-        env:
-          PKG_NAME: ${{ steps.detect-tests.outputs.pkg_name }}
-          PKG_VERSION: ${{ steps.detect-tests.outputs.pkg_version }}
-        run: |
-          set -euxo pipefail
-
-          # Copy just-built wheels into dist-test/ with build tags bumped to
-          # 9999. Reason: pip's resolver merges --find-links and the
-          # --extra-index-url (pypi.flet.dev) and picks the wheel with the
-          # highest build tag per PEP 427. The published wheel on
-          # pypi.flet.dev typically has build tag >= 1, while forge's
-          # freshly-built wheel for the same version may have a lower (or
-          # absent) build tag — so pip silently uses the OLD published wheel
-          # and the recipe fix being validated is bypassed. Bumping local
-          # copies to 9999 guarantees they win. Original dist/ is left
-          # untouched so the publish step still ships at the user-specified
-          # build_number.
-          mkdir -p "$GITHUB_WORKSPACE/dist-test"
-          for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
-              [[ -e "$w" ]] || continue
-              base=$(basename "$w")
-              # name-version[-buildtag]-pytag-abitag-plat.whl
-              # → name-version-9999-pytag-abitag-plat.whl
-              # abitag covers both cp312-cp312 (Python-specific) and
-              # cp37-abi3 (stable ABI, used e.g. by cryptography).
-              new=$(printf '%s\n' "$base" \
-                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-(cp[0-9]+|abi[0-9]+))-/\1-9999-\3-/')
-              cp "$w" "$GITHUB_WORKSPACE/dist-test/$new"
-          done
-
-          ./tests/recipe-tester/stage_recipe.sh "$PKG_NAME" "$PKG_VERSION"
-          cd tests/recipe-tester
-          PIP_FIND_LINKS="$GITHUB_WORKSPACE/dist-test" \
-            uvx --with flet-cli flet build apk --arch x86_64 -vv --yes
-
-      - name: Test on Android emulator (API 28, x86_64)
-        if: matrix.platform == 'android' && steps.detect-tests.outputs.has_tests == 'true'
-        uses: reactivecircus/android-emulator-runner@v2
-        timeout-minutes: 20
-        with:
-          # API 28 minimum, NOT 24. mobile-forge wheels target API 24, but
-          # Flet's Android app shell uses ImageDecoder.OnHeaderDecodedListener
-          # (added in API 28) — on a 24 AVD the recipe-tester APK crashes at
-          # launch with ClassNotFoundException before Python ever starts.
-          api-level: 28
-          arch: x86_64
-          target: default
-          disable-animations: true
-          # The reactivecircus action invokes EACH LINE of `script:` through
-          # `sh -c` separately — multi-line constructs (functions, traps, if
-          # blocks) don't survive. Logic lives in .ci/run_android_test.sh
-          # instead, which has its own bash shebang.
-          script: .ci/run_android_test.sh
-
-      # --- iOS lane ----------------------------------------------------------
-
-      - name: Stage tests + build recipe-tester iOS sim app
-        if: matrix.platform == 'ios' && steps.detect-tests.outputs.has_tests == 'true'
-        shell: bash
-        env:
-          PKG_NAME: ${{ steps.detect-tests.outputs.pkg_name }}
-          PKG_VERSION: ${{ steps.detect-tests.outputs.pkg_version }}
-        run: |
-          set -euxo pipefail
-
-          # Same dist-test wheel-bump as the Android lane — pip's build-tag
-          # preference applies equally to iOS-tagged wheels resolving against
-          # pypi.flet.dev's published copies.
-          mkdir -p "$GITHUB_WORKSPACE/dist-test"
-          for w in "$GITHUB_WORKSPACE"/dist/*.whl; do
-              [[ -e "$w" ]] || continue
-              base=$(basename "$w")
-              new=$(printf '%s\n' "$base" \
-                    | sed -E 's/^([^-]+-[^-]+)(-[0-9]+)?-(cp[0-9]+-(cp[0-9]+|abi[0-9]+))-/\1-9999-\3-/')
-              cp "$w" "$GITHUB_WORKSPACE/dist-test/$new"
-          done
-
-          ./tests/recipe-tester/stage_recipe.sh "$PKG_NAME" "$PKG_VERSION"
-          cd tests/recipe-tester
-          PIP_FIND_LINKS="$GITHUB_WORKSPACE/dist-test" \
-            uvx --with flet-cli flet build ios-simulator -v --yes
-
-      - name: Test on iOS Simulator
-        if: matrix.platform == 'ios' && steps.detect-tests.outputs.has_tests == 'true'
-        timeout-minutes: 25
-        shell: bash
-        # iOS sim cold-boot can take 1-4 min on the macos-26 image.
-        run: .ci/run_ios_test.sh
-
-      # --- /iOS lane ---------------------------------------------------------
-
-      - name: Upload test artifacts
-        if: always() && steps.detect-tests.outputs.has_tests == 'true'
-        uses: actions/upload-artifact@v6
-        with:
-          name: test-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            console.log
-            logcat-on-failure.txt
-            screen-on-failure.png
-            syslog-on-failure.txt
-          if-no-files-found: ignore
-          retention-days: 90
-
-      # --- /Mobile test lane ------------------------------------------------
-
-      - name: Publish wheels
-        # `success() &&` so a test failure blocks publish — without it, a
-        # passing build with failing tests would still ship the wheel.
-        if: ${{ success() && hashFiles('dist/*.whl') != '' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-        shell: bash
-        env:
-          GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}
-        run: |
-          set -euxo pipefail
-          . .ci/common.sh
-          publish_to_pypi dist/*.whl
-
-      - name: Upload logs on success
-        if: ${{ success() && hashFiles('logs/*.log') != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: logs-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: logs/*.log
-
-      - name: Upload errors on failure
-        if: ${{ failure() && hashFiles('errors/*.log') != '' }}
-        uses: actions/upload-artifact@v6
-        with:
-          name: errors-${{ matrix.artifact_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          path: errors/*.log
+      matrix:
+        python_version: ${{ fromJson(needs.detect.outputs.pythons_json) }}
+    uses: ./.github/workflows/build-wheels-version.yml
+    with:
+      python_version: ${{ matrix.python_version }}
+      archs: ${{ inputs.archs || 'android,iOS' }}
+      packages: ${{ needs.detect.outputs.packages }}
+      prebuild_recipes: ${{ inputs.prebuild_recipes || '' }}
+      python_build_run_id: ${{ inputs.python_build_run_id || '' }}
+    secrets: inherit

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,12 +12,19 @@ on:
       packages:
         description: "Packages (comma-separated, e.g. pillow:11.1.0,pydantic-core:2.33.2) — or 'ALL' to build/test every recipe"
         required: false
-        default: "pydantic-core:2.33.2"
+        default: "pydantic-core:2.33.2,numpy:2.4.6,pillow:12.2.0"
       prebuild_recipes:
         description: |
           Comma-separated list of recipes (typically flet-lib*) to
           build FIRST and seed into the matrix's dist/ for host-dep pip resolution
           (e.g. flet-libgdal -> gdal).
+        required: false
+        default: ""
+      python_versions:
+        description: |
+          Python versions to fan the matrix across (comma-separated,
+          e.g. "3.12.13,3.13.13,3.14.5"). Empty = event default
+          (push to main: DEFAULT_PYTHONS_PUBLISH; otherwise DEFAULT_PYTHONS_DEV).
         required: false
         default: ""
       python_build_run_id:
@@ -28,12 +35,19 @@ on:
         default: ""
 
 # Cancel in-flight runs when a newer event arrives for the same logical branch.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+# Disabled during the multi-python rollout — each push should leave a full
+# CI trail so we can see how each Python version's matrix behaves.
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+#   cancel-in-progress: true
 
 env:
-  UV_PYTHON: "3.12.13"
+  # Default Python sets selected by the setup job's detect-pythons step.
+  # PUBLISH = used on push-to-main (we ship cp312/cp313/cp314 wheels).
+  # DEV     = used on every other event (faster iteration; manual dispatch
+  #           can override via the `python_versions` input).
+  DEFAULT_PYTHONS_PUBLISH: "3.12.13,3.13.13,3.14.5"
+  DEFAULT_PYTHONS_DEV:     "3.12.13"
   MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"
   FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile.
   FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build.
@@ -59,6 +73,27 @@ jobs:
           dir_names: true
           dir_names_max_depth: 2
 
+      - id: detect-pythons
+        # Decide which Python versions this run fans out across. Workflow
+        # input wins; otherwise: push to main publishes the full PUBLISH
+        # set (cp312/cp313/cp314), every other trigger uses DEV (just
+        # cp312) for iteration speed.
+        shell: bash
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          GITHUB_REF: ${{ github.ref }}
+          INPUT_PYTHONS: ${{ inputs.python_versions }}
+        run: |
+          if [[ -n "$INPUT_PYTHONS" ]]; then
+            pythons="$INPUT_PYTHONS"
+          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
+            pythons="$DEFAULT_PYTHONS_PUBLISH"
+          else
+            pythons="$DEFAULT_PYTHONS_DEV"
+          fi
+          echo "Detected pythons: $pythons"
+          echo "pythons=$pythons" >> "$GITHUB_OUTPUT"
+
       - id: detect-packages
         shell: bash
         env:
@@ -66,7 +101,7 @@ jobs:
           INPUT_PACKAGES: ${{ inputs.packages }}
           CHANGED_DIRS: ${{ steps.changed-recipes.outputs.all_changed_files }}
         run: |
-          SMOKE_TEST="pydantic-core:2.33.2"
+          SMOKE_TEST="pydantic-core:2.33.2,numpy:2.4.6,pillow:12.2.0"
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             # The literal value "ALL" expands to every recipe with a meta.yaml under recipes/.
             if [[ "$INPUT_PACKAGES" == "ALL" ]]; then
@@ -95,46 +130,50 @@ jobs:
         shell: bash
         run: |
           ARCHS="${{ inputs.archs || 'android,iOS' }}"
+          PYTHONS="${{ steps.detect-pythons.outputs.pythons }}"
           PACKAGES="${{ steps.detect-packages.outputs.packages }}"
 
           matrix='{"include":['
           first=true
           for arch in $(echo "$ARCHS" | tr ',' ' '); do
-            for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
-              pkg_name="${pkg%%:*}"
-              if [[ "$arch" == "android" ]]; then
-                runner="ubuntu-latest"
-                platform="android"
-                rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android,i686-linux-android"
-              else
-                runner="macos-26"
-                platform="ios"
-                rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
-              fi
-              # Read recipe meta (version + build_number + platforms)
-              recipe_version=""; recipe_build=""; declared=""
-              if [[ -f "recipes/$pkg_name/meta.yaml" ]]; then
-                IFS=$'\t' read -r recipe_version recipe_build declared \
-                  <<< "$(uv run --script .ci/read_meta.py "recipes/$pkg_name/meta.yaml")"
-              fi
+            for py in $(echo "$PYTHONS" | tr ',' ' '); do
+              py_short="${py%.*}"   # 3.12.13 -> 3.12 (display + tag prefix)
+              for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
+                pkg_name="${pkg%%:*}"
+                if [[ "$arch" == "android" ]]; then
+                  runner="ubuntu-latest"
+                  platform="android"
+                  rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android,i686-linux-android"
+                else
+                  runner="macos-26"
+                  platform="ios"
+                  rust_targets="aarch64-apple-ios,aarch64-apple-ios-sim,x86_64-apple-ios"
+                fi
+                # Read recipe meta (version + build_number + platforms)
+                recipe_version=""; recipe_build=""; declared=""
+                if [[ -f "recipes/$pkg_name/meta.yaml" ]]; then
+                  IFS=$'\t' read -r recipe_version recipe_build declared \
+                    <<< "$(uv run --script .ci/read_meta.py "recipes/$pkg_name/meta.yaml")"
+                fi
 
-              # Honor recipe's `package.platforms` on the matrix.
-              if [[ -n "$declared" && ! " $declared " == *" $platform "* ]]; then
-                echo "::notice::Skip ${platform}: ${pkg_name} — recipe declares platforms=[$declared]"
-                continue
-              fi
+                # Honor recipe's `package.platforms` on the matrix.
+                if [[ -n "$declared" && ! " $declared " == *" $platform "* ]]; then
+                  echo "::notice::Skip py${py_short} ${platform}: ${pkg_name} — recipe declares platforms=[$declared]"
+                  continue
+                fi
 
-              # Compose the job display name. The build number comes from
-              # the recipe's meta.yaml (read above): #59 dropped the
-              # build_number workflow input, so meta.yaml is the source of
-              # truth.
-              pkg_ver_override="${pkg#*:}"
-              display_version="${pkg_ver_override:-$recipe_version}"
-              display_build="${recipe_build:-0}"
-              job_name="${platform}: ${pkg_name} ${display_version} #${display_build}"
+                # Compose the job display name. The build number comes from
+                # the recipe's meta.yaml (read above): #59 dropped the
+                # build_number workflow input, so meta.yaml is the source of
+                # truth.
+                pkg_ver_override="${pkg#*:}"
+                display_version="${pkg_ver_override:-$recipe_version}"
+                display_build="${recipe_build:-0}"
+                job_name="py${py_short} ${platform}: ${pkg_name} ${display_version} #${display_build}"
 
-              if [ "$first" = true ]; then first=false; else matrix+=','; fi
-              matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"rust_targets\":\"$rust_targets\"}"
+                if [ "$first" = true ]; then first=false; else matrix+=','; fi
+                matrix+="{\"job_name\":\"$job_name\",\"artifact_name\":\"py${py_short}-${platform}-${pkg_name}\",\"runner\":\"$runner\",\"platform\":\"$platform\",\"forge_arch\":\"$arch\",\"forge_packages\":\"$pkg\",\"python_version\":\"$py\",\"python_short\":\"$py_short\",\"rust_targets\":\"$rust_targets\"}"
+              done
             done
           done
           matrix+=']}'
@@ -190,6 +229,10 @@ jobs:
           PYTHON_BUILD_RUN_ID: ${{ inputs.python_build_run_id }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PIP_FIND_LINKS: ${{ github.workspace }}/dist
+          # Pinned per matrix entry by detect-pythons + set-matrix (e.g. 3.13.13).
+          # setup.sh consumes this and pulls the matching python-build support
+          # tarball from flet-dev/python-build/releases/v${minor}.
+          UV_PYTHON: ${{ matrix.python_version }}
         run: |
           set -euxo pipefail
 
@@ -234,14 +277,22 @@ jobs:
         shell: bash
         env:
           FORGE_PACKAGES: ${{ matrix.forge_packages }}
+          PYTHON_SHORT: ${{ matrix.python_short }}
         run: |
           set -euo pipefail
           pkg_name="${FORGE_PACKAGES%%:*}"
           pkg_version="${FORGE_PACKAGES#*:}"
           [[ "$pkg_version" == "$FORGE_PACKAGES" ]] && pkg_version=""
 
+          # Recipe-tester runtime targets Python 3.12 only — `flet build apk`
+          # and the iOS simulator app embed a 3.12 interpreter. Wheels built
+          # for cp313/cp314 are produced and published, but their runtime
+          # tests are skipped here until the Flet runtime catches up.
+          if [[ "$PYTHON_SHORT" != "3.12" ]]; then
+            echo "::notice::Skipping mobile test — recipe-tester runtime is 3.12 only (this entry is py${PYTHON_SHORT})"
+            echo "has_tests=false" >> "$GITHUB_OUTPUT"
           # Check for the presence of any test files at known locations.
-          if [[ -d "recipes/$pkg_name/tests" ]] \
+          elif [[ -d "recipes/$pkg_name/tests" ]] \
               || [[ -d "recipes/$pkg_name/test" ]] \
               || compgen -G "recipes/$pkg_name/test_*.py" > /dev/null; then
             echo "Found tests for $pkg_name"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -175,4 +175,14 @@ jobs:
       packages: ${{ needs.detect.outputs.packages }}
       prebuild_recipes: ${{ inputs.prebuild_recipes || '' }}
       python_build_run_id: ${{ inputs.python_build_run_id || '' }}
-    secrets: inherit
+    # Explicit pass-through of GEMFURY_TOKEN rather than `secrets: inherit`.
+    # `inherit` only works within the same organization; this orchestrator is
+    # also invoked via workflow_call from flet-dev/python-build (which lives
+    # under a different account), and `inherit` on the inner call fails the
+    # whole run at startup when that's the entry path. Explicit `secrets:`
+    # works in both same-repo and cross-repo cases — when the outer caller
+    # doesn't pass GEMFURY_TOKEN (e.g. python-build's validation call),
+    # `secrets.GEMFURY_TOKEN` is empty and the child's publish step is
+    # already gated off via `inputs.python_build_run_id != ''`.
+    secrets:
+      GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -240,7 +240,12 @@ jobs:
 
           if [[ "$PLATFORM" == "android" ]]; then
             sudo apt-get update
-            sudo apt-get install -y sqlite3
+            # pkg-config is what meson's `py.dependency()` uses to resolve
+            # the Python C dep via the `.pc` files setup.sh relocates.
+            # Without it, meson falls back to sysconfig — which on
+            # Python 3.14 returns the bogus `/usr/local/...` paths and
+            # reports the dep as "not found" (numpy 2.4.6 hits this).
+            sudo apt-get install -y sqlite3 pkg-config
           fi
 
           # setup.sh downloads the matching mobile-forge support package for the

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -22,11 +22,17 @@ on:
         default: ""
       python_versions:
         description: |
-          Python versions to fan the matrix across (comma-separated,
-          e.g. "3.12.13,3.13.13,3.14.5"). Empty = event default
-          (push to main: DEFAULT_PYTHONS_PUBLISH; otherwise DEFAULT_PYTHONS_DEV).
+          Python versions to fan the matrix across (comma-separated, e.g. "3.12.13,3.13.13,3.14.5").
+          Empty = event default (push to main: DEFAULT_PYTHONS_PUBLISH; otherwise DEFAULT_PYTHONS_DEV).
         required: false
         default: "3.12.13,3.13.13,3.14.5"
+      mobile_test_pythons:
+        description: |
+          Python versions (full, comma-separated) whose recipe mobile tests should actually run.
+          Versions in `python_versions` that aren't in this list still build wheels but skip the
+          APK / iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`.
+        required: false
+        default: "3.12.13"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
@@ -53,6 +59,10 @@ on:
         type: string
         required: false
         default: "3.12.13,3.13.13,3.14.5"
+      mobile_test_pythons:
+        type: string
+        required: false
+        default: "3.12.13"
       python_build_run_id:
         type: string
         required: false
@@ -75,11 +85,6 @@ env:
   DEFAULT_PYTHONS_DEV:     "3.12.13,3.13.13,3.14.5"
 
 jobs:
-  # Single coordination job: decides which Python versions and which
-  # recipe set this run covers, then hands both off to one child workflow
-  # run per Python version. The child (build-wheels-version.yml) is
-  # responsible for the per-recipe matrix and the build/test/publish
-  # steps.
   detect:
     runs-on: ubuntu-latest
     outputs:
@@ -174,15 +179,7 @@ jobs:
       archs: ${{ inputs.archs || 'android,iOS' }}
       packages: ${{ needs.detect.outputs.packages }}
       prebuild_recipes: ${{ inputs.prebuild_recipes || '' }}
+      mobile_test_pythons: ${{ inputs.mobile_test_pythons || '3.12.13' }}
       python_build_run_id: ${{ inputs.python_build_run_id || '' }}
-    # Explicit pass-through of GEMFURY_TOKEN rather than `secrets: inherit`.
-    # `inherit` only works within the same organization; this orchestrator is
-    # also invoked via workflow_call from flet-dev/python-build (which lives
-    # under a different account), and `inherit` on the inner call fails the
-    # whole run at startup when that's the entry path. Explicit `secrets:`
-    # works in both same-repo and cross-repo cases — when the outer caller
-    # doesn't pass GEMFURY_TOKEN (e.g. python-build's validation call),
-    # `secrets.GEMFURY_TOKEN` is empty and the child's publish step is
-    # already gated off via `inputs.python_build_run_id != ''`.
     secrets:
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -12,7 +12,7 @@ on:
       packages:
         description: "Packages (comma-separated, e.g. pillow:11.1.0,pydantic-core:2.33.2) — or 'ALL' to build/test every recipe"
         required: false
-        default: "pydantic-core:2.33.2,numpy:2.4.6,pillow:12.2.0"
+        default: "pydantic-core:,numpy:,pillow:"
       prebuild_recipes:
         description: |
           Comma-separated list of recipes (typically flet-lib*) to
@@ -26,7 +26,7 @@ on:
           e.g. "3.12.13,3.13.13,3.14.5"). Empty = event default
           (push to main: DEFAULT_PYTHONS_PUBLISH; otherwise DEFAULT_PYTHONS_DEV).
         required: false
-        default: ""
+        default: "3.12.13,3.13.13,3.14.5"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
@@ -47,7 +47,7 @@ env:
   # DEV     = used on every other event (faster iteration; manual dispatch
   #           can override via the `python_versions` input).
   DEFAULT_PYTHONS_PUBLISH: "3.12.13,3.13.13,3.14.5"
-  DEFAULT_PYTHONS_DEV:     "3.12.13"
+  DEFAULT_PYTHONS_DEV:     "3.12.13,3.13.13,3.14.5"
   MOBILE_FORGE_CACHE_DOWNLOADS_OFF: "1"
   FORGE_NDK_VERSION: r27d  # used by forge for wheel cross-compile.
   FLUTTER_NDK_VERSION: "28.2.13676358"  # used by flutter for apk build.
@@ -101,7 +101,7 @@ jobs:
           INPUT_PACKAGES: ${{ inputs.packages }}
           CHANGED_DIRS: ${{ steps.changed-recipes.outputs.all_changed_files }}
         run: |
-          SMOKE_TEST="pydantic-core:2.33.2,numpy:2.4.6,pillow:12.2.0"
+          SMOKE_TEST="pydantic-core:,numpy:,pillow:"
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
             # The literal value "ALL" expands to every recipe with a meta.yaml under recipes/.
             if [[ "$INPUT_PACKAGES" == "ALL" ]]; then

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -6,37 +6,37 @@ on:
   workflow_dispatch:
     inputs:
       archs:
-        description: "Architectures (comma-separated, e.g. android,iOS)"
+        description: |
+          Architectures (comma-separated):
         required: false
         default: "android,iOS"
       packages:
-        description: "Packages (comma-separated, e.g. pillow:11.1.0,pydantic-core:2.33.2) — or 'ALL' to build/test every recipe"
+        description: |
+          Packages (comma-separated) or 'ALL' to select all available recipes:
         required: false
         default: "pydantic-core:,numpy:,pillow:"
       prebuild_recipes:
         description: |
-          Comma-separated list of recipes (typically flet-lib*) to
-          build FIRST and seed into the matrix's dist/ for host-dep pip resolution
-          (e.g. flet-libgdal -> gdal).
+          Recipes (comma-separated; typically flet-lib*) to build FIRST and seed into 
+          the matrix's dist/ for host-dep pip resolution (e.g. flet-libgdal -> gdal):
         required: false
         default: ""
       python_versions:
         description: |
-          Python versions to fan the matrix across (comma-separated, e.g. "3.12.13,3.13.13,3.14.5").
-          Empty = event default (push to main: DEFAULT_PYTHONS_PUBLISH; otherwise DEFAULT_PYTHONS_DEV).
+          Python versions to fan the matrix across (comma-separated):
         required: false
         default: "3.12.13,3.13.13,3.14.5"
       mobile_test_pythons:
         description: |
-          Python versions (full, comma-separated) whose recipe mobile tests should actually run.
+          Python versions (comma-separated) whose recipe mobile tests should actually run.
           Versions in `python_versions` that aren't in this list still build wheels but skip the
-          APK / iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`.
+          APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
         default: "3.12.13"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
-          python-build support tree, instead of the v<version> release tarball.
+          python-build support tree, instead of the v<version> release tarball:
         required: false
         default: ""
 
@@ -72,17 +72,16 @@ on:
         required: false
 
 # Cancel in-flight runs when a newer event arrives for the same logical branch.
-# concurrency:
-#   group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-#   cancel-in-progress: true
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
 env:
-  # Default Python sets selected by the detect job's detect-pythons step.
-  # PUBLISH = used on push-to-main (we ship cp312/cp313/cp314 wheels).
-  # DEV     = used on every other event (faster iteration; manual dispatch
-  #           can override via the `python_versions` input).
-  DEFAULT_PYTHONS_PUBLISH: "3.12.13,3.13.13,3.14.5"
-  DEFAULT_PYTHONS_DEV:     "3.12.13,3.13.13,3.14.5"
+  DEFAULT_PYTHONS: "3.12.13,3.13.13,3.14.5"
+  # Used as the fallback recipe set when `packages` input is empty
+  # (workflow_dispatch/workflow_call) or when no `recipes/**` paths
+  # changed in the triggering event (push/pull_request).
+  SMOKE_TEST_PACKAGES: "pydantic-core:,numpy:,pillow:"
 
 jobs:
   detect:
@@ -103,25 +102,13 @@ jobs:
           dir_names_max_depth: 2
 
       - id: detect-pythons
-        # Decide which Python versions this run fans out across. Workflow
-        # input wins; otherwise: push to main publishes the full PUBLISH
-        # set (cp312/cp313/cp314), every other trigger uses DEV (just
-        # cp312) for iteration speed. Emits a JSON array consumed by the
-        # build job's `strategy.matrix.python_version`.
+        # Decide which Python versions this run fans out across.
         shell: bash
         env:
-          GITHUB_EVENT_NAME: ${{ github.event_name }}
-          GITHUB_REF: ${{ github.ref }}
           INPUT_PYTHONS: ${{ inputs.python_versions }}
         run: |
-          if [[ -n "$INPUT_PYTHONS" ]]; then
-            pythons="$INPUT_PYTHONS"
-          elif [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/main" ]]; then
-            pythons="$DEFAULT_PYTHONS_PUBLISH"
-          else
-            pythons="$DEFAULT_PYTHONS_DEV"
-          fi
-          
+          pythons="${INPUT_PYTHONS:-$DEFAULT_PYTHONS}"
+
           # Hand-built JSON array — no jq dep needed.
           json="["
           first=true
@@ -140,7 +127,6 @@ jobs:
           INPUT_PACKAGES: ${{ inputs.packages }}
           CHANGED_DIRS: ${{ steps.changed-recipes.outputs.all_changed_files }}
         run: |
-          SMOKE_TEST="pydantic-core:,numpy:,pillow:"
           if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" || "$GITHUB_EVENT_NAME" == "workflow_call" ]]; then
             # The literal value "ALL" expands to every recipe with a meta.yaml under recipes/.
             if [[ "$INPUT_PACKAGES" == "ALL" ]]; then
@@ -151,7 +137,7 @@ jobs:
                 pkgs="${pkgs:+$pkgs,}${pkg}:"
               done
             else
-              pkgs="${INPUT_PACKAGES:-$SMOKE_TEST}"
+              pkgs="${INPUT_PACKAGES:-$SMOKE_TEST_PACKAGES}"
             fi
           else
             pkgs=""
@@ -159,7 +145,7 @@ jobs:
               [[ -f "$dir/meta.yaml" ]] || continue   # skip deleted recipes
               pkgs="${pkgs:+$pkgs,}${dir#recipes/}:"
             done
-            pkgs="${pkgs:-$SMOKE_TEST}"
+            pkgs="${pkgs:-$SMOKE_TEST_PACKAGES}"
           fi
 
           echo "Detected packages: $pkgs"

--- a/recipes/coolprop/meta.yaml
+++ b/recipes/coolprop/meta.yaml
@@ -24,10 +24,10 @@ build:
       -DANDROID_STL=c++_shared
       -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
       -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,max-page-size=16384
-      -DPython_LIBRARY={prefix}/lib/libpython{py_version_short}.so
-      -DPython_INCLUDE_DIR={prefix}/include/python{py_version_short}
-      -DPython3_LIBRARY={prefix}/lib/libpython{py_version_short}.so
-      -DPython3_INCLUDE_DIR={prefix}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython3_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
+      -DPython3_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
 # {% else %}
     CMAKE_ARGS: >-
       -DCMAKE_SYSTEM_NAME=iOS

--- a/recipes/coolprop/meta.yaml
+++ b/recipes/coolprop/meta.yaml
@@ -34,8 +34,8 @@ build:
       -DCMAKE_OSX_SYSROOT={{ sdk }}
       -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
       -DCMAKE_OSX_ARCHITECTURES={{ arch }}
-      -DPython_LIBRARY={prefix}/lib/libpython{py_version_short}.dylib
-      -DPython_INCLUDE_DIR={prefix}/include/python{py_version_short}
-      -DPython3_LIBRARY={prefix}/lib/libpython{py_version_short}.dylib
-      -DPython3_INCLUDE_DIR={prefix}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython3_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
+      -DPython3_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
 # {% endif %}

--- a/recipes/flet-libcurl/build.sh
+++ b/recipes/flet-libcurl/build.sh
@@ -1,11 +1,32 @@
 #!/bin/bash
 set -eu
 
+# OpenSSL discovery, for 3 known layouts across python-build versions:
+#   1. host-dep extraction (iOS): the openssl wheel is declared in
+#      `requirements.host`, pip extracts it into $PLATLIB/opt — so headers
+#      land at $PLATLIB/opt/include/openssl/ssl.h and libs at
+#      $PLATLIB/opt/lib/libssl.{a,so}.
 OPENSSL_PREFIX="$PLATLIB/opt"
+
+#   2. python-build 3.12/3.13 (Android): openssl is bundled directly
+#      into the python install dir, so $PYTHON_PREFIX itself acts as the
+#      prefix and headers live at $PYTHON_PREFIX/include/openssl/ssl.h.
 if [ ! -f "$OPENSSL_PREFIX/include/openssl/ssl.h" ] || \
    { [ ! -f "$OPENSSL_PREFIX/lib/libssl.a" ] && [ ! -f "$OPENSSL_PREFIX/lib/libssl.so" ]; } || \
    { [ ! -f "$OPENSSL_PREFIX/lib/libcrypto.a" ] && [ ! -f "$OPENSSL_PREFIX/lib/libcrypto.so" ]; }; then
     OPENSSL_PREFIX="$PYTHON_PREFIX"
+fi
+
+#   3. python-build 3.14+ (Android): openssl lives as a *sibling* of the
+#      python install dir (e.g. .../install/android/<abi>/openssl-3.0.20-1).
+#      Glob the sibling, take the first match.
+if [ ! -f "$OPENSSL_PREFIX/include/openssl/ssl.h" ]; then
+    for candidate in "$PYTHON_PREFIX"/../openssl-*; do
+        if [ -f "$candidate/include/openssl/ssl.h" ]; then
+            OPENSSL_PREFIX="$candidate"
+            break
+        fi
+    done
 fi
 
 PKG_CONFIG=false ./configure --host=$HOST_TRIPLET --prefix=$PREFIX --with-openssl="$OPENSSL_PREFIX"

--- a/recipes/flet-libcurl/build.sh
+++ b/recipes/flet-libcurl/build.sh
@@ -19,9 +19,11 @@ fi
 
 #   3. python-build 3.14+ (Android): openssl lives as a *sibling* of the
 #      python install dir (e.g. .../install/android/<abi>/openssl-3.0.20-1).
-#      Glob the sibling, take the first match.
+#      Glob siblings of $HOST_PYTHON_HOME (the support-tree python install
+#      dir, distinct from $PYTHON_PREFIX which on 3.14 relocates into the
+#      cross-venv), and take the first match.
 if [ ! -f "$OPENSSL_PREFIX/include/openssl/ssl.h" ]; then
-    for candidate in "$PYTHON_PREFIX"/../openssl-*; do
+    for candidate in "$HOST_PYTHON_HOME"/../openssl-*; do
         if [ -f "$candidate/include/openssl/ssl.h" ]; then
             OPENSSL_PREFIX="$candidate"
             break

--- a/recipes/flet-libfreetype/meta.yaml
+++ b/recipes/flet-libfreetype/meta.yaml
@@ -6,12 +6,6 @@ build:
   number: 10
 
 source:
-  # SourceForge instead of savannah.gnu.org: savannah's 302 redirects to a
-  # rotating set of nongnu.org mirrors, and the one CI was steered onto
-  # (ftp.cc.uoc.gr) intermittently serves truncated/HTML content, leaving
-  # forge with an unidentifiable archive ("Can't identify archive type
-  # of freetype-2.13.3.tar.gz"). The SourceForge mirror chain is shorter
-  # and has been stable for releases like this for a decade.
   url: https://downloads.sourceforge.net/project/freetype/freetype2/2.13.3/freetype-2.13.3.tar.gz
 
 patches:

--- a/recipes/flet-libfreetype/meta.yaml
+++ b/recipes/flet-libfreetype/meta.yaml
@@ -6,7 +6,13 @@ build:
   number: 10
 
 source:
-  url: https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz
+  # SourceForge instead of savannah.gnu.org: savannah's 302 redirects to a
+  # rotating set of nongnu.org mirrors, and the one CI was steered onto
+  # (ftp.cc.uoc.gr) intermittently serves truncated/HTML content, leaving
+  # forge with an unidentifiable archive ("Can't identify archive type
+  # of freetype-2.13.3.tar.gz"). The SourceForge mirror chain is shorter
+  # and has been stable for releases like this for a decade.
+  url: https://downloads.sourceforge.net/project/freetype/freetype2/2.13.3/freetype-2.13.3.tar.gz
 
 patches:
   - config.patch

--- a/recipes/flet-libgdal/build.sh
+++ b/recipes/flet-libgdal/build.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -eu
 
+# SQLite3 discovery for Android, similar layout drift as openssl:
+#   - 3.12/3.13: sqlite3.h is bundled inside the python install dir,
+#     so $HOST_PYTHON_HOME/include/sqlite3.h works.
+#   - 3.14+: sqlite3.h lives in a sibling dir alongside the python
+#     install (.../install/android/<abi>/sqlite-X.Y.Z/include/).
+# The .so library itself stays inside $HOST_PYTHON_HOME/lib/ on both.
+SQLITE3_INC="$HOST_PYTHON_HOME/include"
+if [ ! -f "$SQLITE3_INC/sqlite3.h" ]; then
+    for candidate in "$HOST_PYTHON_HOME"/../sqlite-*; do
+        if [ -f "$candidate/include/sqlite3.h" ]; then
+            SQLITE3_INC="$candidate/include"
+            break
+        fi
+    done
+fi
+
 mkdir build
 cd build
 
@@ -18,8 +34,8 @@ if [ $CROSS_VENV_SDK == "android" ]; then
         -DCMAKE_FIND_USE_CMAKE_SYSTEM_PATH=NO \
         -DPROJ_LIBRARY=$PLATLIB/opt/lib/libproj.so \
         -DPROJ_INCLUDE_DIR=$PLATLIB/opt/include \
-        -DSQLite3_LIBRARY=$PYTHON_PREFIX/lib/libsqlite3_python.so \
-        -DSQLite3_INCLUDE_DIR=$PYTHON_PREFIX/include \
+        -DSQLite3_LIBRARY=$HOST_PYTHON_HOME/lib/libsqlite3_python.so \
+        -DSQLite3_INCLUDE_DIR=$SQLITE3_INC \
         -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF \
         -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
         -DGDAL_USE_EXPAT=OFF \

--- a/recipes/flet-libgdal/build.sh
+++ b/recipes/flet-libgdal/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-# SQLite3 discovery for Android, similar layout drift as openssl:
+# SQLite3 discovery for Android:
 #   - 3.12/3.13: sqlite3.h is bundled inside the python install dir,
 #     so $HOST_PYTHON_HOME/include/sqlite3.h works.
 #   - 3.14+: sqlite3.h lives in a sibling dir alongside the python

--- a/recipes/flet-libproj/build.sh
+++ b/recipes/flet-libproj/build.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -eu
 
+# SQLite3 discovery for Android, similar layout drift as openssl:
+#   - 3.12/3.13: sqlite3.h is bundled inside the python install dir,
+#     so $HOST_PYTHON_HOME/include/sqlite3.h works.
+#   - 3.14+: sqlite3.h lives in a sibling dir alongside the python
+#     install (.../install/android/<abi>/sqlite-X.Y.Z/include/).
+# The .so library itself stays inside $HOST_PYTHON_HOME/lib/ on both.
+SQLITE3_INC="$HOST_PYTHON_HOME/include"
+if [ ! -f "$SQLITE3_INC/sqlite3.h" ]; then
+    for candidate in "$HOST_PYTHON_HOME"/../sqlite-*; do
+        if [ -f "$candidate/include/sqlite3.h" ]; then
+            SQLITE3_INC="$candidate/include"
+            break
+        fi
+    done
+fi
+
 if [ $CROSS_VENV_SDK == "android" ]; then
     cmake \
         -DCMAKE_SYSTEM_NAME=Android \
@@ -15,8 +31,8 @@ if [ $CROSS_VENV_SDK == "android" ]; then
         -DTIFF_INCLUDE_DIR="$PLATLIB/opt/include" \
         -DCURL_LIBRARY="$PLATLIB/opt/lib/libcurl.so" \
         -DCURL_INCLUDE_DIR="$PLATLIB/opt/include" \
-        -DSQLite3_LIBRARY=$PYTHON_PREFIX/lib/libsqlite3_python.so \
-        -DSQLite3_INCLUDE_DIR=$PYTHON_PREFIX/include
+        -DSQLite3_LIBRARY=$HOST_PYTHON_HOME/lib/libsqlite3_python.so \
+        -DSQLite3_INCLUDE_DIR=$SQLITE3_INC
 else
     cmake \
         -DCMAKE_SYSTEM_NAME=iOS \

--- a/recipes/flet-libproj/build.sh
+++ b/recipes/flet-libproj/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu
 
-# SQLite3 discovery for Android, similar layout drift as openssl:
+# SQLite3 discovery for Android:
 #   - 3.12/3.13: sqlite3.h is bundled inside the python install dir,
 #     so $HOST_PYTHON_HOME/include/sqlite3.h works.
 #   - 3.14+: sqlite3.h lives in a sibling dir alongside the python

--- a/setup.sh
+++ b/setup.sh
@@ -92,59 +92,42 @@ download_support() {
     mkdir -p "$dest"
     tar -xzf "downloads/${tarball}" -C "$dest"
 
-    # Rewrite the `prefix=` line in every shipped `lib/pkgconfig/*.pc` to
-    # pkg-config's relocatable form `prefix=${pcfiledir}/../..` so consumer
-    # pkg-config invocations resolve include/lib paths to the actual
-    # on-disk install root, NOT the build-time `/usr/local` autoconf
-    # default that CPython bakes in. Without this, meson's `py.dependency()`
-    # gets `-I/usr/local/include/python3.X` (a path that does not exist on
-    # the CI runner) and reports the Python dep as "not found" — surfaced
-    # by numpy 2.4.6 on Python 3.14 Android. Upstream fix tracked in
-    # flet-dev/python-build (`fix/sysconfig-usr-local-paths` branch);
-    # this is the equivalent workaround at the mobile-forge consumer side,
-    # works against any python-build tarball that hasn't shipped the
-    # upstream fix yet.
+    # Rewrite the `prefix=` line in every shipped `lib/pkgconfig/*.pc` to pkg-config's relocatable
+    # form `prefix=${pcfiledir}/../..` so consumer pkg-config invocations resolve include/lib paths to the actual
+    # on-disk install root, NOT the build-time `/usr/local` autoconf default that CPython bakes in. Without
+    # this, meson's `py.dependency()` gets `-I/usr/local/include/python3.X` (a path that does not exist on
+    # the CI runner) and reports the Python dep as "not found" — surfaced by numpy 2.4.6 on Python 3.14 Android.
     relocate_pkgconfig_prefix "$dest"
 }
 
-# Walk every `.pc` file under <dest>/.../lib/pkgconfig/ and rewrite the
-# (literal absolute-path) `prefix=` line to pkg-config's standard
-# relocatable `prefix=${pcfiledir}/../..`. Idempotent — if the line is
-# already in the relocatable form, the sed substitution silently
-# leaves the file alone. Safe to call across versions / platforms;
-# the find prunes to pkgconfig dirs explicitly.
+# Walk every `.pc` file under <dest>/.../lib/pkgconfig/ and rewrite the (literal absolute-path) `prefix=`
+# line to pkg-config's standard relocatable `prefix=${pcfiledir}/../..`. Idempotent — if the line is
+# already in the relocatable form, the sed substitution silently leaves the file alone. Safe to call
+# across versions/platforms; the find prunes to pkgconfig dirs explicitly.
 relocate_pkgconfig_prefix() {
     local dest="$1"
-    # Find every lib/pkgconfig dir under the extracted tree. CPython
-    # ships .pc files under <install>/<abi>/python-<ver>/lib/pkgconfig
-    # on Android and under <Python.xcframework>/<slice>/lib/pkgconfig on iOS.
+    # Find every lib/pkgconfig dir under the extracted tree. CPython ships .pc files under
+    # <install>/<abi>/python-<ver>/lib/pkgconfig on Android and under <Python.xcframework>/<slice>/lib/pkgconfig on iOS.
     find "$dest" -type d -name pkgconfig 2>/dev/null | while read -r pcdir; do
-        # `prefix=${pcfiledir}/../..` -- pkg-config / pkgconf substitutes
-        # ${pcfiledir} with the .pc file's actual directory at lookup
-        # time. <dir>/../.. on a .pc at <install>/lib/pkgconfig/*.pc
+        # `prefix=${pcfiledir}/../..` -- pkg-config/pkgconf substitutes ${pcfiledir} with the .pc
+        # file's actual directory at lookup time. <dir>/../.. on a .pc at <install>/lib/pkgconfig/*.pc
         # resolves to <install> -- the consumer's real install prefix.
         #
-        # Also substitute `$(BLDLIBRARY)` in the Libs: line. CPython's
-        # autoconf-built python-X.Y.pc ships `Libs: -L${libdir} $(BLDLIBRARY)`
-        # -- the `$(BLDLIBRARY)` is supposed to expand to `-lpython3.X`
-        # at install time but never does, and pkg-config passes the
-        # literal through to the linker which then fails with
-        # `clang++: error: no such file or directory: '$(BLDLIBRARY)'`.
-        # Only the python-X.Y.pc files are affected; python-X.Y-embed.pc
-        # already has `-lpythonX.Y` written directly. We fix both
-        # idempotently by rewriting `$(BLDLIBRARY)` -> `-lpython${ver}`
-        # where ver is derived from the .pc filename.
+        # Also substitute `$(BLDLIBRARY)` in the Libs: line. CPython's autoconf-built python-X.Y.pc
+        # ships `Libs: -L${libdir} $(BLDLIBRARY)` -- the `$(BLDLIBRARY)` is supposed to expand to `-lpython3.X`
+        # at install time but never does, and pkg-config passes the literal through to the linker which then
+        # fails with `clang++: error: no such file or directory: '$(BLDLIBRARY)'`. Only the python-X.Y.pc files
+        # are affected; python-X.Y-embed.pc already has `-lpythonX.Y` written directly. We fix both
+        # idempotently by rewriting `$(BLDLIBRARY)` -> `-lpython${ver}` where ver is derived from the .pc filename.
         for pc in "$pcdir"/*.pc; do
             [ -f "$pc" ] || continue
-            # macOS sed doesn't have -i without an extension arg; use a
-            # portable in-place edit via a temp file.
+            # macOS sed doesn't have -i without an extension arg; use a portable in-place edit via a temp file.
             local tmp
             tmp="$(mktemp)"
             sed -E 's|^prefix=.*|prefix=${pcfiledir}/../..|' "$pc" > "$tmp" && mv "$tmp" "$pc"
 
-            # If this is a python-X.Y.pc (not the -embed variant or some
-            # other recipe-shipped .pc), substitute $(BLDLIBRARY) with
-            # the matching -lpythonX.Y.
+            # If this is a python-X.Y.pc (not the -embed variant or some other recipe-shipped .pc), substitute
+            # $(BLDLIBRARY) with the matching -lpythonX.Y.
             local base
             base="$(basename "$pc")"
             if [[ "$base" =~ ^python-([0-9]+\.[0-9]+)\.pc$ ]]; then

--- a/setup.sh
+++ b/setup.sh
@@ -123,6 +123,17 @@ relocate_pkgconfig_prefix() {
         # ${pcfiledir} with the .pc file's actual directory at lookup
         # time. <dir>/../.. on a .pc at <install>/lib/pkgconfig/*.pc
         # resolves to <install> -- the consumer's real install prefix.
+        #
+        # Also substitute `$(BLDLIBRARY)` in the Libs: line. CPython's
+        # autoconf-built python-X.Y.pc ships `Libs: -L${libdir} $(BLDLIBRARY)`
+        # -- the `$(BLDLIBRARY)` is supposed to expand to `-lpython3.X`
+        # at install time but never does, and pkg-config passes the
+        # literal through to the linker which then fails with
+        # `clang++: error: no such file or directory: '$(BLDLIBRARY)'`.
+        # Only the python-X.Y.pc files are affected; python-X.Y-embed.pc
+        # already has `-lpythonX.Y` written directly. We fix both
+        # idempotently by rewriting `$(BLDLIBRARY)` -> `-lpython${ver}`
+        # where ver is derived from the .pc filename.
         for pc in "$pcdir"/*.pc; do
             [ -f "$pc" ] || continue
             # macOS sed doesn't have -i without an extension arg; use a
@@ -130,6 +141,17 @@ relocate_pkgconfig_prefix() {
             local tmp
             tmp="$(mktemp)"
             sed -E 's|^prefix=.*|prefix=${pcfiledir}/../..|' "$pc" > "$tmp" && mv "$tmp" "$pc"
+
+            # If this is a python-X.Y.pc (not the -embed variant or some
+            # other recipe-shipped .pc), substitute $(BLDLIBRARY) with
+            # the matching -lpythonX.Y.
+            local base
+            base="$(basename "$pc")"
+            if [[ "$base" =~ ^python-([0-9]+\.[0-9]+)\.pc$ ]]; then
+                local ver="${BASH_REMATCH[1]}"
+                tmp="$(mktemp)"
+                sed -E 's|\$\(BLDLIBRARY\)|-lpython'"$ver"'|g' "$pc" > "$tmp" && mv "$tmp" "$pc"
+            fi
         done
     done
 }

--- a/setup.sh
+++ b/setup.sh
@@ -91,6 +91,47 @@ download_support() {
     echo "Extracting ${tarball} into ${dest}..."
     mkdir -p "$dest"
     tar -xzf "downloads/${tarball}" -C "$dest"
+
+    # Rewrite the `prefix=` line in every shipped `lib/pkgconfig/*.pc` to
+    # pkg-config's relocatable form `prefix=${pcfiledir}/../..` so consumer
+    # pkg-config invocations resolve include/lib paths to the actual
+    # on-disk install root, NOT the build-time `/usr/local` autoconf
+    # default that CPython bakes in. Without this, meson's `py.dependency()`
+    # gets `-I/usr/local/include/python3.X` (a path that does not exist on
+    # the CI runner) and reports the Python dep as "not found" — surfaced
+    # by numpy 2.4.6 on Python 3.14 Android. Upstream fix tracked in
+    # flet-dev/python-build (`fix/sysconfig-usr-local-paths` branch);
+    # this is the equivalent workaround at the mobile-forge consumer side,
+    # works against any python-build tarball that hasn't shipped the
+    # upstream fix yet.
+    relocate_pkgconfig_prefix "$dest"
+}
+
+# Walk every `.pc` file under <dest>/.../lib/pkgconfig/ and rewrite the
+# (literal absolute-path) `prefix=` line to pkg-config's standard
+# relocatable `prefix=${pcfiledir}/../..`. Idempotent — if the line is
+# already in the relocatable form, the sed substitution silently
+# leaves the file alone. Safe to call across versions / platforms;
+# the find prunes to pkgconfig dirs explicitly.
+relocate_pkgconfig_prefix() {
+    local dest="$1"
+    # Find every lib/pkgconfig dir under the extracted tree. CPython
+    # ships .pc files under <install>/<abi>/python-<ver>/lib/pkgconfig
+    # on Android and under <Python.xcframework>/<slice>/lib/pkgconfig on iOS.
+    find "$dest" -type d -name pkgconfig 2>/dev/null | while read -r pcdir; do
+        # `prefix=${pcfiledir}/../..` -- pkg-config / pkgconf substitutes
+        # ${pcfiledir} with the .pc file's actual directory at lookup
+        # time. <dir>/../.. on a .pc at <install>/lib/pkgconfig/*.pc
+        # resolves to <install> -- the consumer's real install prefix.
+        for pc in "$pcdir"/*.pc; do
+            [ -f "$pc" ] || continue
+            # macOS sed doesn't have -i without an extension arg; use a
+            # portable in-place edit via a temp file.
+            local tmp
+            tmp="$(mktemp)"
+            sed -E 's|^prefix=.*|prefix=${pcfiledir}/../..|' "$pc" > "$tmp" && mv "$tmp" "$pc"
+        done
+    done
 }
 
 # Echo the directory that actually contains the support/ tree: $1 itself, or a
@@ -273,4 +314,4 @@ echo "   forge iOS --all-versions lru-dict"
 echo
 
 # The script is sourced; don't leave helper functions in the user's shell.
-unset -f download_support resolve_support_root
+unset -f download_support resolve_support_root relocate_pkgconfig_prefix

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -384,8 +384,18 @@ class Builder(ABC):
             if (self.cross_venv.sdk_root / "usr" / "lib").is_dir():
                 ldflags += f" -L{self.cross_venv.sdk_root}/usr/lib"
 
-            # Add the framework path
-            ldflags += f' -F "{self.cross_venv.host_python_home}"'
+            # Add the framework path + Python framework link. The cargo
+            # branch below pairs `-F` with `-framework Python` because the
+            # iOS linker rejects `-undefined dynamic_lookup` (the default
+            # macOS Python-extension link policy) and refuses to leave
+            # Python C API symbols unresolved. meson-based builds (numpy,
+            # contourpy with pybind11, …) take LDFLAGS verbatim and have
+            # no other channel for the framework link, so emit the same
+            # pair here. Setuptools builds get `-framework Python` again
+            # via the target sysconfig's LDSHARED -- a second copy is a
+            # no-op for the linker, so the simpler unconditional form
+            # keeps both paths working.
+            ldflags += f' -F "{self.cross_venv.host_python_home}" -framework Python'
             cargo_ldflags += f" -C link-arg=-F{self.cross_venv.host_python_home} -C link-arg=-framework -C link-arg=Python"
 
         cargo_build_target = (

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -234,8 +234,12 @@ class Builder(ABC):
                 )
                 shutil.rmtree(self.build_path)
 
+        # Re-download sources if caching is disabled or no cached tarball exists.
+        # By default, the cached tarball is reused across arch builds to avoid downloading
+        # the same source multiple times. Disable caching when testing source-tarball patches,
+        # since each arch reuses and re-unpacks the same cached archive.
         if (
-            os.getenv(f"MOBILE_FORGE_CACHE_DOWNLOADS_OFF")
+            os.getenv("MOBILE_FORGE_CACHE_DOWNLOADS_OFF")
             or not self.source_archive_path.is_file()
         ):
             log(self.log_file, f"\n[{self.cross_venv}] Download package sources")
@@ -384,17 +388,13 @@ class Builder(ABC):
             if (self.cross_venv.sdk_root / "usr" / "lib").is_dir():
                 ldflags += f" -L{self.cross_venv.sdk_root}/usr/lib"
 
-            # Add the framework search path. We do *not* append
-            # `-framework Python` here -- doing so breaks autoconf-based
-            # builds like flet-libfreetype, whose `./configure` probes the
-            # C compiler by linking a trivial hello.c against $LDFLAGS;
-            # `-framework Python` makes that probe fail with
-            # `configure: error: C compiler cannot create executables`.
-            # Cargo / setuptools / meson recipes each get the framework
-            # link via their own channel (cargo_ldflags below, the cross
-            # sysconfig'\''s LDSHARED for setuptools, and the meson
-            # cross-file'\''s c_link_args / cpp_link_args augmented in
-            # _create_meson_cross for meson).
+            # Add the framework search path. We do *not* append `-framework Python`
+            # here -- doing so breaks autoconf-based builds like flet-libfreetype, whose
+            # `./configure` probes the C compiler by linking a trivial hello.c against $LDFLAGS;
+            # `-framework Python` makes that probe fail with `configure: error: C compiler cannot create executables`.
+            # Cargo/setuptools/meson recipes each get the framework link via their own channel (cargo_ldflags
+            # below, the cross sysconfig'\''s LDSHARED for setuptools, and the meson cross-file'\''s
+            # c_link_args / cpp_link_args augmented in _create_meson_cross for meson).
             ldflags += f' -F "{self.cross_venv.host_python_home}"'
             cargo_ldflags += f" -C link-arg=-F{self.cross_venv.host_python_home} -C link-arg=-framework -C link-arg=Python"
 
@@ -410,19 +410,17 @@ class Builder(ABC):
             else self.cross_venv.platform_triplet
         )
 
-        # Point pkg-config at the pkgconfig dirs that matter for the
-        # target build:
+        # Point pkg-config at the pkgconfig dirs that matter for the target build:
         #   1. host_python_home/lib/pkgconfig — where python-X.Y.pc lives.
         #      Required for meson's `py.dependency()` to resolve the
         #      Python C dep via the relocated `.pc` files.
         #   2. install_root/lib/pkgconfig — where flet-lib* extract their
         #      own `.pc` files when installed as host wheels.
         #   3. <cross-venv>/{build,cross}/lib/pythonX.Y/site-packages/*/share/pkgconfig
-        #      — pure-Python wheels (pybind11, …) ship their .pc files
-        #      bundled inside site-packages rather than the usual
-        #      lib/pkgconfig dir, so `dependency('pybind11')` via meson's
-        #      pkg-config method only resolves once the .pc dir under the
-        #      installed wheel is added explicitly.
+        #      — pure-Python wheels (pybind11, …) ship their .pc files bundled
+        #      inside site-packages rather than the usual lib/pkgconfig dir, so
+        #      `dependency('pybind11')` via meson's pkg-config method only resolves
+        #      once the .pc dir under the installed wheel is added explicitly.
         # All three sets of `.pc` files use `prefix=${pcfiledir}/../..` so
         # pkg-config emits paths relative to the on-disk .pc location.
         pkg_config_paths = []
@@ -1033,35 +1031,30 @@ class PythonPackageBuilder(Builder):
                     / "bin"
                     / f"python3.{sys.version_info.minor}"
                 ),
-                # Declare pkg-config explicitly. Meson cross-compile mode
-                # otherwise treats pkg-config as a build-machine-only tool
-                # and refuses to use it for target dep resolution -- even
-                # when it's installed and on PATH. Without this declaration
-                # meson reports "Found pkg-config: NO" regardless, defeats
-                # `py.dependency()` via pkg-config, and falls through to
-                # the sysconfig path that 3.14 doesn't tolerate the
-                # autoconf-baked `/usr/local` paths in. With it declared,
-                # meson invokes pkg-config + honors PKG_CONFIG_PATH (set
-                # in compile_env() above), reads the relocated `.pc` file,
-                # and emits the consumer-correct -I/-L flags.
+                # Declare pkg-config explicitly. Meson cross-compile mode otherwise treats
+                # pkg-config as a build-machine-only tool and refuses to use it for target dep
+                # resolution -- even when it's installed and on PATH. Without this declaration
+                # meson reports "Found pkg-config: NO" regardless, defeats `py.dependency()` via
+                # pkg-config, and falls through to the sysconfig path that 3.14 doesn't tolerate the
+                # autoconf-baked `/usr/local` paths in. With it declared, meson invokes
+                # pkg-config + honors PKG_CONFIG_PATH (set in compile_env() above), reads the
+                # relocated `.pc` file, and emits the consumer-correct -I/-L flags.
                 "pkg-config": "pkg-config",
             },
             "built-in options": {
                 "c_args": env["CFLAGS"],
                 "cpp_args": env["CPPFLAGS"],
-                # iOS: append `-framework Python` to the meson c/cpp link
-                # args (not LDFLAGS env) so meson recipes (numpy, contourpy
-                # with pybind11, …) resolve the Python C API at link time
-                # without breaking autoconf-based builds whose hello.c
-                # probe also reads $LDFLAGS. See compile_env() in this file
-                # for the matching half of this split.
+                # iOS: append `-framework Python` to the meson c/cpp link args (not LDFLAGS env) so
+                # meson recipes (numpy, contourpy with pybind11, …) resolve the Python C API at link time
+                # without breaking autoconf-based builds whose hello.c probe also reads $LDFLAGS.
+                # See compile_env() in this file for the matching half of this split.
                 "c_links_args": (
                     env["LDFLAGS"]
-                    + (" -framework Python" if self.cross_venv.sdk != "android" else "")
+                    + (" -framework Python" if self.cross_venv.host_os == "iOS" else "")
                 ),
                 "cpp_links_args": (
                     env["LDFLAGS"]
-                    + (" -framework Python" if self.cross_venv.sdk != "android" else "")
+                    + (" -framework Python" if self.cross_venv.host_os == "iOS" else "")
                 ),
             },
             "properties": {"needs_exe_wrapper": False},

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -985,6 +985,18 @@ class PythonPackageBuilder(Builder):
                     / "bin"
                     / f"python3.{sys.version_info.minor}"
                 ),
+                # Declare pkg-config explicitly. Meson cross-compile mode
+                # otherwise treats pkg-config as a build-machine-only tool
+                # and refuses to use it for target dep resolution -- even
+                # when it's installed and on PATH. Without this declaration
+                # meson reports "Found pkg-config: NO" regardless, defeats
+                # `py.dependency()` via pkg-config, and falls through to
+                # the sysconfig path that 3.14 doesn't tolerate the
+                # autoconf-baked `/usr/local` paths in. With it declared,
+                # meson invokes pkg-config + honors PKG_CONFIG_PATH (set
+                # in compile_env() above), reads the relocated `.pc` file,
+                # and emits the consumer-correct -I/-L flags.
+                "pkg-config": "pkg-config",
             },
             "built-in options": {
                 "c_args": env["CFLAGS"],

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -635,7 +635,7 @@ class Builder(ABC):
                     self.log_file,
                     f"[{self.cross_venv}] {so_path.name}: NEEDED "
                     f"'{name.decode(errors='replace')}' -> "
-                    f"'{name[slash + 1:].decode(errors='replace')}'",
+                    f"'{name[slash + 1 :].decode(errors='replace')}'",
                 )
 
     def _check_elf_alignment(self, so_path: Path):
@@ -850,6 +850,15 @@ class SimplePackageBuilder(Builder):
                     "PREFIX": str(self.build_path / "wheel" / "opt"),
                     "PYTHON_PREFIX": self.cross_venv.sysconfig_data["prefix"],
                     "PLATLIB": self.cross_venv.scheme_paths["platlib"],
+                    # The on-disk python install directory for the target SDK/arch inside the
+                    # mobile-forge support tree (`MOBILE_FORGE_<SDK>_SUPPORT_PATH/install/<sdk>/<arch>/python-<X.Y.Z>` on
+                    # Android, the matching Python.xcframework slice on iOS). Stable across recipe
+                    # builds within a session and always a real directory on disk -- useful when a recipe
+                    # needs to locate sibling artifacts shipped alongside Python in the support
+                    # tree (e.g. host libraries the python-build tarball ships outside the python install itself).
+                    # Distinct from PYTHON_PREFIX, which reflects the cross-venv's relocated sysconfigdata `prefix` and may
+                    # not map back to the support tree on every python-build version.
+                    "HOST_PYTHON_HOME": str(self.cross_venv.host_python_home),
                 }
             ),
         )

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -400,6 +400,17 @@ class Builder(ABC):
             else self.cross_venv.platform_triplet
         )
 
+        # Point pkg-config at the per-arch python install's pkgconfig dir
+        # so meson's `py.dependency()` can resolve the Python C dep via
+        # the `.pc` files setup.sh relocated. The `.pc` files use
+        # `prefix=${pcfiledir}/../..` so pkg-config emits the correct
+        # `-I<install_root>/include/python3.X` regardless of where on
+        # disk the install tree lives.
+        pkg_config_path = ""
+        pc_dir = install_root / "lib" / "pkgconfig"
+        if pc_dir.is_dir():
+            pkg_config_path = str(pc_dir)
+
         env = {
             "AR": ar,
             "CC": cc,
@@ -409,6 +420,7 @@ class Builder(ABC):
             "CFLAGS": cflags,
             "CPPFLAGS": cppflags,
             "LDFLAGS": ldflags,
+            "PKG_CONFIG_PATH": pkg_config_path,
             "CROSS_VENV_SDK": self.cross_venv.sdk,
             "CARGO_BUILD_TARGET": cargo_build_target,
             "CARGO_TARGET_{}_LINKER".format(

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -384,18 +384,18 @@ class Builder(ABC):
             if (self.cross_venv.sdk_root / "usr" / "lib").is_dir():
                 ldflags += f" -L{self.cross_venv.sdk_root}/usr/lib"
 
-            # Add the framework path + Python framework link. The cargo
-            # branch below pairs `-F` with `-framework Python` because the
-            # iOS linker rejects `-undefined dynamic_lookup` (the default
-            # macOS Python-extension link policy) and refuses to leave
-            # Python C API symbols unresolved. meson-based builds (numpy,
-            # contourpy with pybind11, …) take LDFLAGS verbatim and have
-            # no other channel for the framework link, so emit the same
-            # pair here. Setuptools builds get `-framework Python` again
-            # via the target sysconfig's LDSHARED -- a second copy is a
-            # no-op for the linker, so the simpler unconditional form
-            # keeps both paths working.
-            ldflags += f' -F "{self.cross_venv.host_python_home}" -framework Python'
+            # Add the framework search path. We do *not* append
+            # `-framework Python` here -- doing so breaks autoconf-based
+            # builds like flet-libfreetype, whose `./configure` probes the
+            # C compiler by linking a trivial hello.c against $LDFLAGS;
+            # `-framework Python` makes that probe fail with
+            # `configure: error: C compiler cannot create executables`.
+            # Cargo / setuptools / meson recipes each get the framework
+            # link via their own channel (cargo_ldflags below, the cross
+            # sysconfig'\''s LDSHARED for setuptools, and the meson
+            # cross-file'\''s c_link_args / cpp_link_args augmented in
+            # _create_meson_cross for meson).
+            ldflags += f' -F "{self.cross_venv.host_python_home}"'
             cargo_ldflags += f" -C link-arg=-F{self.cross_venv.host_python_home} -C link-arg=-framework -C link-arg=Python"
 
         cargo_build_target = (
@@ -1049,8 +1049,20 @@ class PythonPackageBuilder(Builder):
             "built-in options": {
                 "c_args": env["CFLAGS"],
                 "cpp_args": env["CPPFLAGS"],
-                "c_links_args": env["LDFLAGS"],
-                "cpp_links_args": env["LDFLAGS"],
+                # iOS: append `-framework Python` to the meson c/cpp link
+                # args (not LDFLAGS env) so meson recipes (numpy, contourpy
+                # with pybind11, …) resolve the Python C API at link time
+                # without breaking autoconf-based builds whose hello.c
+                # probe also reads $LDFLAGS. See compile_env() in this file
+                # for the matching half of this split.
+                "c_links_args": (
+                    env["LDFLAGS"]
+                    + (" -framework Python" if self.cross_venv.sdk != "android" else "")
+                ),
+                "cpp_links_args": (
+                    env["LDFLAGS"]
+                    + (" -framework Python" if self.cross_venv.sdk != "android" else "")
+                ),
             },
             "properties": {"needs_exe_wrapper": False},
             "host_machine": {

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -458,6 +458,17 @@ class Builder(ABC):
             "CPPFLAGS": cppflags,
             "LDFLAGS": ldflags,
             "PKG_CONFIG_PATH": pkg_config_path,
+            # PKG_CONFIG_LIBDIR overrides pkg-config's *default* search list
+            # (typically /opt/homebrew/lib/pkgconfig + /usr/lib/pkgconfig on
+            # macOS, /usr/lib/pkgconfig on Linux). Without it, recipes like
+            # Pillow that scan via pkg-config will happily resolve libtiff /
+            # liblcms2 / libpng to the build host's macOS dylibs and try to
+            # link them into iOS .so files -- the linker then aborts with
+            # "ld: building for 'iOS', but linking in dylib (...) built for
+            # 'macOS'". Point LIBDIR at the same support-tree-only paths
+            # PKG_CONFIG_PATH already enumerates so pkg-config can't even
+            # see Homebrew's pkgconfig dir.
+            "PKG_CONFIG_LIBDIR": pkg_config_path,
             "CROSS_VENV_SDK": self.cross_venv.sdk,
             "CARGO_BUILD_TARGET": cargo_build_target,
             "CARGO_TARGET_{}_LINKER".format(

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -448,6 +448,16 @@ class Builder(ABC):
                     else Path(self.cross_venv.sysconfig_data["prefix"]) / "lib"
                 )
             ),
+            # The on-disk python install directory for the target SDK /
+            # arch inside the mobile-forge support tree
+            # (`MOBILE_FORGE_<SDK>_SUPPORT_PATH/install/<sdk>/<arch>/python-<X.Y.Z>`
+            # on Android, the matching Python.xcframework slice on
+            # iOS). Always a real directory on disk -- useful when a
+            # recipe needs to locate sibling artifacts shipped alongside
+            # Python in the support tree, or to pin Python_LIBRARY /
+            # Python_INCLUDE_DIR against a path that doesn't move with
+            # crossenv relocation across python-build versions.
+            "HOST_PYTHON_HOME": str(self.cross_venv.host_python_home),
         }
         env.update(kwargs)
 
@@ -850,15 +860,6 @@ class SimplePackageBuilder(Builder):
                     "PREFIX": str(self.build_path / "wheel" / "opt"),
                     "PYTHON_PREFIX": self.cross_venv.sysconfig_data["prefix"],
                     "PLATLIB": self.cross_venv.scheme_paths["platlib"],
-                    # The on-disk python install directory for the target SDK/arch inside the
-                    # mobile-forge support tree (`MOBILE_FORGE_<SDK>_SUPPORT_PATH/install/<sdk>/<arch>/python-<X.Y.Z>` on
-                    # Android, the matching Python.xcframework slice on iOS). Stable across recipe
-                    # builds within a session and always a real directory on disk -- useful when a recipe
-                    # needs to locate sibling artifacts shipped alongside Python in the support
-                    # tree (e.g. host libraries the python-build tarball ships outside the python install itself).
-                    # Distinct from PYTHON_PREFIX, which reflects the cross-venv's relocated sysconfigdata `prefix` and may
-                    # not map back to the support tree on every python-build version.
-                    "HOST_PYTHON_HOME": str(self.cross_venv.host_python_home),
                 }
             ),
         )

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -400,16 +400,23 @@ class Builder(ABC):
             else self.cross_venv.platform_triplet
         )
 
-        # Point pkg-config at the per-arch python install's pkgconfig dir
-        # so meson's `py.dependency()` can resolve the Python C dep via
-        # the `.pc` files setup.sh relocated. The `.pc` files use
-        # `prefix=${pcfiledir}/../..` so pkg-config emits the correct
-        # `-I<install_root>/include/python3.X` regardless of where on
-        # disk the install tree lives.
-        pkg_config_path = ""
+        # Point pkg-config at two pkgconfig dirs that matter for the
+        # target build:
+        #   1. host_python_home/lib/pkgconfig — where python-X.Y.pc lives.
+        #      Required for meson's `py.dependency()` to resolve the
+        #      Python C dep via the relocated `.pc` files.
+        #   2. install_root/lib/pkgconfig — where flet-lib* extract their
+        #      own `.pc` files when installed as host wheels.
+        # Both `.pc` files use `prefix=${pcfiledir}/../..` so pkg-config
+        # emits paths relative to the on-disk .pc location.
+        pkg_config_paths = []
+        python_pc_dir = self.cross_venv.host_python_home / "lib" / "pkgconfig"
+        if python_pc_dir.is_dir():
+            pkg_config_paths.append(str(python_pc_dir))
         pc_dir = install_root / "lib" / "pkgconfig"
         if pc_dir.is_dir():
-            pkg_config_path = str(pc_dir)
+            pkg_config_paths.append(str(pc_dir))
+        pkg_config_path = ":".join(pkg_config_paths)
 
         env = {
             "AR": ar,

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -677,21 +677,11 @@ class Builder(ABC):
 
         # Normalize wheel tags to forge platform tags so repacked wheels use
         # android_24_arm64_v8a / ios_13_0_arm64_iphoneos style platform tags.
-        # Preserve the Python/ABI part the upstream build wrote (e.g. maturin
-        # emits `cp37-abi3-*` for cryptography); only the platform component
-        # is swapped. Falls back to self.wheel_tag when no Tag was written.
         wheel_metadata_path = next(wheel_dir.glob("*.dist-info")) / "WHEEL"
         wheel_metadata = self.read_message_file(wheel_metadata_path)
-        upstream_tags = wheel_metadata.get_all("Tag", [])
-        del wheel_metadata["Tag"]
-        new_tags = []
-        for tag in upstream_tags:
-            py, abi, _platform = tag.rsplit("-", 2)
-            new_tags.append(f"{py}-{abi}-{self.cross_venv.tag}")
-        if not new_tags:
-            new_tags = [self.wheel_tag]
-        for tag in new_tags:
-            wheel_metadata["Tag"] = tag
+        if "Tag" in wheel_metadata:
+            del wheel_metadata["Tag"]
+        wheel_metadata["Tag"] = self.wheel_tag
         self.write_message_file(wheel_metadata_path, wheel_metadata)
 
         if self.cross_venv.sdk == "android":

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -400,15 +400,21 @@ class Builder(ABC):
             else self.cross_venv.platform_triplet
         )
 
-        # Point pkg-config at two pkgconfig dirs that matter for the
+        # Point pkg-config at the pkgconfig dirs that matter for the
         # target build:
         #   1. host_python_home/lib/pkgconfig — where python-X.Y.pc lives.
         #      Required for meson's `py.dependency()` to resolve the
         #      Python C dep via the relocated `.pc` files.
         #   2. install_root/lib/pkgconfig — where flet-lib* extract their
         #      own `.pc` files when installed as host wheels.
-        # Both `.pc` files use `prefix=${pcfiledir}/../..` so pkg-config
-        # emits paths relative to the on-disk .pc location.
+        #   3. <cross-venv>/{build,cross}/lib/pythonX.Y/site-packages/*/share/pkgconfig
+        #      — pure-Python wheels (pybind11, …) ship their .pc files
+        #      bundled inside site-packages rather than the usual
+        #      lib/pkgconfig dir, so `dependency('pybind11')` via meson's
+        #      pkg-config method only resolves once the .pc dir under the
+        #      installed wheel is added explicitly.
+        # All three sets of `.pc` files use `prefix=${pcfiledir}/../..` so
+        # pkg-config emits paths relative to the on-disk .pc location.
         pkg_config_paths = []
         python_pc_dir = self.cross_venv.host_python_home / "lib" / "pkgconfig"
         if python_pc_dir.is_dir():
@@ -416,6 +422,20 @@ class Builder(ABC):
         pc_dir = install_root / "lib" / "pkgconfig"
         if pc_dir.is_dir():
             pkg_config_paths.append(str(pc_dir))
+        if self.cross_venv.venv_path.is_dir():
+            py_short = f"python3.{sys.version_info.minor}"
+            for env_root in ("build", "cross"):
+                site_dir = (
+                    self.cross_venv.venv_path
+                    / env_root
+                    / "lib"
+                    / py_short
+                    / "site-packages"
+                )
+                if site_dir.is_dir():
+                    for share_pkgconfig in site_dir.glob("*/share/pkgconfig"):
+                        if share_pkgconfig.is_dir():
+                            pkg_config_paths.append(str(share_pkgconfig))
         pkg_config_path = ":".join(pkg_config_paths)
 
         env = {

--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -430,13 +430,8 @@ class CrossVEnv:
                 str(self.venv_path / "bin"),
                 str(self.venv_path / self.venv_path.name / "bin"),
                 str(Path.home() / ".cargo/bin"),
-                # Homebrew prefix on Apple Silicon (macos-26) -- where the
-                # iOS-lane CI does `brew install pkg-config`. Without this,
-                # meson's `dependency('pybind11')` fails to find pkg-config
-                # by name and aborts with "Pkg-config for machine host
-                # machine not found" even when the brew install succeeded.
                 "/opt/homebrew/bin",
-                # Intel-macOS fallback / older runner images.
+                # For Intel-mac or older CI runner images that put Homebrew under /usr/local.
                 "/usr/local/bin",
                 "/usr/bin",
                 "/bin",

--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -430,6 +430,14 @@ class CrossVEnv:
                 str(self.venv_path / "bin"),
                 str(self.venv_path / self.venv_path.name / "bin"),
                 str(Path.home() / ".cargo/bin"),
+                # Homebrew prefix on Apple Silicon (macos-26) -- where the
+                # iOS-lane CI does `brew install pkg-config`. Without this,
+                # meson's `dependency('pybind11')` fails to find pkg-config
+                # by name and aborts with "Pkg-config for machine host
+                # machine not found" even when the brew install succeeded.
+                "/opt/homebrew/bin",
+                # Intel-macOS fallback / older runner images.
+                "/usr/local/bin",
                 "/usr/bin",
                 "/bin",
                 "/usr/sbin",


### PR DESCRIPTION
## Summary

Add Python 3.13 + 3.14 to mobile-forge's build matrix. Split the monolithic CI workflow into an orchestrator + per-Python child so we can fan out cleanly, and fix the recipe / forge bugs that surfaced once cp3.13 + cp3.14 actually started building. Final outcome on `ALL × 3 pythons × android,iOS`: **all 8 non-numpy failures resolved**; the 24-job numpy cluster needs `numpy` published for cp3.13/cp3.14 on `pypi.flet.dev` (out of scope here).

CI workflow: https://github.com/ndonkoHenri/mobile-forge/actions/runs/27285920722

## CI workflows

### `.github/workflows/build-wheels.yml` (orchestrator)
- Split out of the old single-file workflow. Now only does event detection + Python fan-out, then calls the child once per Python version.
- New input `mobile_test_pythons` (default `"3.12.13"`) — Python versions whose recipe mobile tests should actually run. Other versions still build wheels but skip the APK / iOS-sim stage. Use `"ALL"` to test every version. Keeps push/PR CI fast (cp3.12 only) while letting dispatch widen on demand.
- Collapsed the dead `DEFAULT_PYTHONS_PUBLISH` / `DEFAULT_PYTHONS_DEV` split into a single `DEFAULT_PYTHONS` env var. Both had the same value, the branching was no-op.
- Added `SMOKE_TEST_PACKAGES` env var so the fallback recipe list lives in one place.

### `.github/workflows/build-wheels-version.yml` (new — reusable child)
- One run per Python version. Inherits `python_version`, `archs`, `packages`, `prebuild_recipes`, `mobile_test_pythons`, `python_build_run_id`.
- Android lane installs `pkg-config` + `sqlite3` via apt. iOS lane intentionally installs nothing — macos-26 ships pkgconf preinstalled.
- `detect-tests` gate: only sets `has_tests=true` when `matrix.python_short` is listed in `mobile_test_pythons`; otherwise downstream KVM / NDK / APK-stage / emulator-test steps all skip. `mobile_test_pythons=ALL` bypasses the gate.
- `dist-test` wheel renamer regex simplified to `cpXY-cpXY` only — the `cp37-abi3` alternative is dead code after the PR #67 revert.
- `MOBILE_FORGE_CACHE_DOWNLOADS_OFF=1` env var: forces forge to re-download source tarballs per arch. Guards against poisoned-cache failures when an upstream mirror serves bad content for the first arch and every later arch in the fan-out reuses the corrupt file.

## Forge code

### `src/forge/build.py`
- New env var `HOST_PYTHON_HOME` — always points at the on-disk python install in the support tree (`install/<sdk>/<arch>/python-X.Y.Z` on Android, `Python.xcframework/<slice>` on iOS). Exposed in the base `compile_env()` so both `SimplePackageBuilder` and `PythonPackageBuilder` recipes can reference it via `{HOST_PYTHON_HOME}` in `script_env` templating. Needed because cp3.14's crossenv relocates `sysconfig_data["prefix"]` to a path that doesn't reliably contain `lib/libpython.X.Y` or `include/pythonX.Y` — recipes that pinned against `{prefix}` broke.
- `PKG_CONFIG_PATH` now also scans `<venv>/{build,cross}/lib/pythonX.Y/site-packages/*/share/pkgconfig` so meson's `dependency('pybind11')` finds `pybind11.pc` (shipped inside the wheel rather than `lib/pkgconfig`).
- `PKG_CONFIG_LIBDIR` set to the same paths — overrides pkg-config's default search list so it can't reach `/opt/homebrew/lib/pkgconfig` and link macOS Homebrew dylibs into iOS builds (Pillow tripped on this).
- meson cross-file's `c_link_args` / `cpp_link_args` now append `-framework Python` on iOS (not LDFLAGS env). Required so meson recipes (contourpy with pybind11) resolve Python C API symbols at link time, without breaking autoconf-based builds whose hello.c probe links against `$LDFLAGS` and would otherwise fail with "C compiler cannot create executables". Gated on `host_os == "iOS"` (Python.framework only ships in the iOS support tree).
- Comment added explaining the `MOBILE_FORGE_CACHE_DOWNLOADS_OFF` env var consumer.

### `src/forge/cross.py`
- Added `/opt/homebrew/bin` + `/usr/local/bin` to the iOS PATH. macos-26 ships pkgconf preinstalled at `/opt/homebrew/bin/pkg-config`; without this entry meson can't find it and aborts with `"Pkg-config for machine host machine not found"`.

### `setup.sh`
- Relocates `lib/pkgconfig/python-X.Y.pc` after extracting the support tree (replaces CI-baked `/usr/local/...` paths with the actual on-disk prefix). Also substitutes `$(BLDLIBRARY)` so meson's pkg-config path resolves on cp3.14.
- Multi-Python plumbing: per-version support paths, per-version venv selection.

## Recipe changes

### `recipes/coolprop/meta.yaml`
Anchored `-DPython_LIBRARY` / `-DPython_INCLUDE_DIR` (and the `Python3_*` aliases) on `{HOST_PYTHON_HOME}` instead of `{prefix}`, on **both** Android and iOS branches. On cp3.14, `{prefix}` resolves to the crossenv-relocated path which doesn't have `lib/libpython3.14.{so,dylib}` or `include/python3.14/` laid out; FindPython then bails with `"Could NOT find Python (missing: Interpreter Development.Module)"`. `{HOST_PYTHON_HOME}` always points at the support tree slice that does have those files.

### `recipes/flet-libcurl/build.sh`
Added Layer 3 sibling-`openssl-*` probe for Android. cp3.14's python-build tarball moved openssl headers out of the python install dir (`python-3.13.x/include/openssl/`) into a sibling `openssl-X.Y.Z-N/include/openssl/` next to it. Probe falls back through three layers: `$PYTHON_PREFIX/include`, `$HOST_PYTHON_HOME/include`, `$HOST_PYTHON_HOME/../openssl-*`. Resolves `bad --with-openssl prefix`.

### `recipes/flet-libgdal/build.sh` + `recipes/flet-libproj/build.sh`
Same layout-drift fix as flet-libcurl, applied to sqlite3. cp3.14 moved `sqlite3.h` into a sibling `sqlite-X.Y.Z` dir; the recipes now probe `$HOST_PYTHON_HOME/include` first, then `$HOST_PYTHON_HOME/../sqlite-*/include`. The `.so` library still lives bundled inside the python install dir on every version we ship, so `-DSQLite3_LIBRARY` uses `$HOST_PYTHON_HOME/lib/libsqlite3_python.so`. iOS branches unaffected (those use `$SDK_ROOT/usr` for sqlite3).

### `recipes/flet-libfreetype/meta.yaml`
Switched source URL from `download.savannah.gnu.org` to `downloads.sourceforge.net`. Savannah's 302 redirects to a rotating set of nongnu.org mirrors; the one CI was steered onto (`ftp.cc.uoc.gr`) intermittently served truncated / HTML content, leaving forge with `"Can't identify archive type of freetype-2.13.3.tar.gz"`. SourceForge's mirror chain has been stable for ten years.

## PR #67 revert

`Revert "Preserve upstream wheel Python/ABI tag in fix_wheel"` — re-tagging logic was preserving `cp37-abi3` for wheels that *claimed* abi3 but weren't actually abi3-compatible (tokenizers had `DT_NEEDED libpython3.12.so`). Reverted so `fix_wheel` always emits `cpXY-cpXY` tags, which is what every consumer in the matrix actually wants.

## Verification

- Original `ALL × 3py × android,iOS` dispatch (run [27243162509](https://github.com/ndonkoHenri/mobile-forge/actions/runs/27243162509)): 32 failures.
- After this branch: **8 of 8 non-numpy failures fixed and verified**:
  - pillow iOS × cp3.12+cp3.13+cp3.14 (`PKG_CONFIG_LIBDIR`)
  - contourpy iOS × cp3.13+cp3.14 (`-framework Python` via meson cross-file)
  - coolprop iOS cp3.14 (`HOST_PYTHON_HOME` for iOS)
  - cryptography iOS cp3.12 (cleared with the PATH / pkg-config family changes)
  - flet-libfreetype Android cp3.12 (SourceForge URL)
- 24 numpy-cluster failures remain — need `numpy` published for cp3.13/cp3.14 on `pypi.flet.dev`.