### PR TITLE
recipe: psutil 7.2.2 (Android only)

### DIFF
--- a/recipes/psutil/meta.yaml
+++ b/recipes/psutil/meta.yaml
@@ -1,0 +1,20 @@
+package:
+  name: psutil
+  version: 7.2.2
+  # Android only. psutil's iOS path would route through its macOS extension
+  # (`_psutil_osx`), which links the `IOKit` framework and uses macOS-only
+  # syscalls (libproc, host_processor_info, sysctl entries) that iOS does not
+  # expose or permits only inside the app sandbox -- it can't build or run
+  # there. Android (linux-kernel + /proc, via `_psutil_linux`) works.
+  platforms: [android]
+
+build:
+  number: 1
+
+patches:
+  # Android reports sys.platform == "android" (CPython 3.13+), which psutil's
+  # platform gate (`LINUX = sys.platform.startswith("linux")`) rejects in both
+  # setup.py and at import ("platform android is not supported"). Android is
+  # linux-kernel-based with /proc, so the `_psutil_linux` extension is correct;
+  # treat "android" as Linux.
+  - mobile.patch

--- a/recipes/psutil/patches/mobile.patch
+++ b/recipes/psutil/patches/mobile.patch
@@ -1,0 +1,11 @@
+--- a/psutil/_common.py	2025-11-26 18:30:32
++++ b/psutil/_common.py	2026-06-15 17:28:13
+@@ -71,7 +71,7 @@
+ 
+ POSIX = os.name == "posix"
+ WINDOWS = os.name == "nt"
+-LINUX = sys.platform.startswith("linux")
++LINUX = sys.platform.startswith(("linux", "android"))
+ MACOS = sys.platform.startswith("darwin")
+ OSX = MACOS  # deprecated alias
+ FREEBSD = sys.platform.startswith(("freebsd", "midnightbsd"))

--- a/recipes/psutil/tests/test_psutil.py
+++ b/recipes/psutil/tests/test_psutil.py
@@ -1,0 +1,31 @@
+def test_cpu_count():
+    """`cpu_count` is backed by the C extension / sysconf on POSIX and is one
+    of the few queries that works inside the mobile sandbox."""
+    import psutil
+
+    logical = psutil.cpu_count()
+    assert logical is None or (isinstance(logical, int) and logical >= 1)
+
+
+def test_virtual_memory():
+    """`virtual_memory()` reads total/available RAM via the native ext
+    (sysconf/sysctl). Total must be a positive byte count."""
+    import psutil
+
+    vm = psutil.virtual_memory()
+    assert vm.total > 0
+    assert 0.0 <= vm.percent <= 100.0
+
+
+def test_current_process():
+    """Construct a Process for our own PID and read a couple of fields that
+    don't require elevated permissions in the sandbox."""
+    import os
+
+    import psutil
+
+    p = psutil.Process(os.getpid())
+    assert p.pid == os.getpid()
+    # memory_info().rss is resident set size in bytes -- always > 0 for a
+    # live process.
+    assert p.memory_info().rss > 0


### PR DESCRIPTION
Adds an Android-only recipe for [psutil](https://pypi.org/project/psutil/) 7.2.2 — one of the most-requested packages in the Packages discussions ([#3285](https://github.com/flet-dev/flet/discussions/3285), [#4739](https://github.com/flet-dev/flet/discussions/4739)). Builds green across cp3.12 / cp3.13 / cp3.14, and the wheel passes its on-device test on an Android emulator.

## Why Android-only

iOS is excluded via `package.platforms: [android]`. psutil's iOS build would route through its macOS extension (`_psutil_osx`), which links the `IOKit` framework and relies on macOS-only syscalls (`libproc`, `host_processor_info`, various `sysctl` entries) that iOS either doesn't expose or only permits inside the app sandbox — it can neither build nor meaningfully run there. Android is linux-kernel-based with `/proc`, so its `_psutil_linux` extension is the correct and fully functional path.

## Patch

`patches/mobile.patch` flips a single line in `psutil/_common.py`: `LINUX = sys.platform.startswith("linux")` → `LINUX = sys.platform.startswith(("linux", "android"))`. CPython 3.13+ reports `sys.platform == "android"` (distinct from `"linux"`), which psutil's platform gate rejects with `"platform android is not supported"` — and it fails this way in *both* `setup.py` (build aborts) and at runtime import (`NotImplementedError`). Because `_common.py` is imported by the build and the runtime alike, the one-line fix covers both. Android being linux-kernel-based, treating `"android"` as Linux selects the correct `_psutil_linux`/`_psutil_posix` extensions.

## Tests

`tests/test_psutil.py` exercises the native extension and a few sandbox-safe queries: `cpu_count`, `virtual_memory` (total RAM via the C ext), and a self-`Process` (`memory_info().rss`).

## Verification

Builds clean on Android arm64 for cp3.12 / cp3.13 / cp3.14 (ships as a real `Py_LIMITED_API` abi3 wheel). The cp3.12 Android-emulator mobile test passes, confirming `_psutil_linux` loads and the queries work at runtime — not just at compile time. iOS is correctly skipped by the platform declaration.