### PR TITLE
recipe: spacy 3.8.13 and its native dependency chain (cymem, murmurhash, preshed, srsly, thinc)

### DIFF
--- a/recipes/cymem/meta.yaml
+++ b/recipes/cymem/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: cymem
+  version: 2.0.13
+
+# {% if sdk == 'android' %}
+requirements:
+  host:
+    # cymem's Cython extension compiles as C++; on Android it links libc++_shared.so,
+    # which the device runtime doesn't provide unless we bundle it.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+build:
+  number: 1

--- a/recipes/cymem/meta.yaml
+++ b/recipes/cymem/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: cymem
   version: 2.0.13
 
+build:
+  number: 1
+
 # {% if sdk == 'android' %}
 requirements:
   host:
@@ -9,6 +12,3 @@ requirements:
     # which the device runtime doesn't provide unless we bundle it.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
-
-build:
-  number: 1

--- a/recipes/cymem/tests/test_cymem.py
+++ b/recipes/cymem/tests/test_cymem.py
@@ -1,4 +1,3 @@
-# cymem — Cython memory pool. https://pypi.org/project/cymem/
 def test_pool():
     from cymem.cymem import Pool
 

--- a/recipes/cymem/tests/test_cymem.py
+++ b/recipes/cymem/tests/test_cymem.py
@@ -1,0 +1,7 @@
+# cymem — Cython memory pool. https://pypi.org/project/cymem/
+def test_pool():
+    from cymem.cymem import Pool
+
+    # Constructing the Cython Pool proves the extension loaded.
+    pool = Pool()
+    assert pool is not None

--- a/recipes/murmurhash/meta.yaml
+++ b/recipes/murmurhash/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: murmurhash
+  version: 1.0.15
+
+# {% if sdk == 'android' %}
+requirements:
+  host:
+    # murmurhash wraps MurmurHash2/3 C++ via Cython; on Android it links
+    # libc++_shared.so, which the device runtime doesn't provide unless bundled.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+build:
+  number: 1

--- a/recipes/murmurhash/meta.yaml
+++ b/recipes/murmurhash/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: murmurhash
   version: 1.0.15
 
+build:
+  number: 1
+
 # {% if sdk == 'android' %}
 requirements:
   host:
@@ -9,6 +12,3 @@ requirements:
     # libc++_shared.so, which the device runtime doesn't provide unless bundled.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
-
-build:
-  number: 1

--- a/recipes/murmurhash/tests/test_murmurhash.py
+++ b/recipes/murmurhash/tests/test_murmurhash.py
@@ -1,4 +1,3 @@
-# murmurhash — MurmurHash2/3 (Cython, C++). https://pypi.org/project/murmurhash/
 def test_hash():
     from murmurhash import hash
 

--- a/recipes/murmurhash/tests/test_murmurhash.py
+++ b/recipes/murmurhash/tests/test_murmurhash.py
@@ -1,0 +1,6 @@
+# murmurhash — MurmurHash2/3 (Cython, C++). https://pypi.org/project/murmurhash/
+def test_hash():
+    from murmurhash import hash
+
+    assert hash("apple") == hash("apple")
+    assert isinstance(hash("apple"), int)

--- a/recipes/preshed/meta.yaml
+++ b/recipes/preshed/meta.yaml
@@ -1,0 +1,21 @@
+package:
+  name: preshed
+  version: 3.0.13
+
+# preshed cimports sibling Cython packages (cymem, murmurhash). Their .pxd
+# files ship inside the installed packages, but preshed's setup.py doesn't put
+# them on Cython's include_path, so cythonize fails to resolve them in the
+# cross-build. The patch adds the build env site-packages to include_path.
+patches:
+  - mobile.patch
+
+# {% if sdk == 'android' %}
+requirements:
+  host:
+    # preshed compiles as C++ (and links its cymem/murmurhash deps, which are C++);
+    # on Android it needs libc++_shared.so at load time.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+build:
+  number: 1

--- a/recipes/preshed/meta.yaml
+++ b/recipes/preshed/meta.yaml
@@ -2,6 +2,10 @@ package:
   name: preshed
   version: 3.0.13
 
+
+build:
+  number: 1
+
 # preshed cimports sibling Cython packages (cymem, murmurhash). Their .pxd
 # files ship inside the installed packages, but preshed's setup.py doesn't put
 # them on Cython's include_path, so cythonize fails to resolve them in the
@@ -17,5 +21,3 @@ requirements:
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
 
-build:
-  number: 1

--- a/recipes/preshed/patches/mobile.patch
+++ b/recipes/preshed/patches/mobile.patch
@@ -1,0 +1,44 @@
+--- a/setup.py
++++ b/setup.py
+@@ -77,6 +77,33 @@
+ 
+         include_dirs = [get_path("include")]
+ 
++        # preshed cimports sibling Cython packages (cymem, murmurhash) whose .pxd
++        # files ship inside the installed packages. crossenv patches sysconfig, so
++        # get_path()/get_paths() return TARGET paths, not the build env's
++        # site-packages where the build deps are actually installed. Locate them via
++        # the import system / sys.path so Cython can resolve the cimports when cross
++        # compiling under `python -m build --no-isolation`.
++        import importlib.util as _ilu
++
++        def _pxd_root(_pkg, _pxd):
++            try:
++                _spec = _ilu.find_spec(_pkg)
++                for _loc in list(getattr(_spec, "submodule_search_locations", None) or []):
++                    _root = os.path.dirname(_loc)
++                    if os.path.isfile(os.path.join(_root, _pkg, _pxd)):
++                        return _root
++            except Exception:
++                pass
++            for _d in sys.path:
++                if _d and os.path.isfile(os.path.join(_d, _pkg, _pxd)):
++                    return _d
++            return None
++
++        _cython_includes = [
++            _p for _p in (_pxd_root("cymem", "cymem.pxd"),
++                          _pxd_root("murmurhash", "mrmr.pxd")) if _p
++        ]
++
+         ext_modules = []
+         for mod_name in MOD_NAMES:
+             mod_path = mod_name.replace(".", "/") + ".pyx"
+@@ -103,6 +130,7 @@
+                 ext_modules,
+                 language_level=2,
+                 compiler_directives={"freethreading_compatible": True},
++                include_path=_cython_includes,
+             ),
+             python_requires=">=3.9,<3.15",
+             install_requires=["cymem>=2.0.2,<2.1.0", "murmurhash>=0.28.0,<1.1.0"],

--- a/recipes/preshed/tests/test_preshed.py
+++ b/recipes/preshed/tests/test_preshed.py
@@ -1,0 +1,18 @@
+# preshed — fast hash maps (Cython, C++; uses cymem/murmurhash).
+# https://pypi.org/project/preshed/
+def test_map():
+    from preshed.maps import PreshMap
+
+    # NB: preshed reserves keys 0 and 1 as internal EMPTY/DELETED sentinels —
+    # they round-trip but don't count toward len(), so use larger keys here.
+    m = PreshMap()
+    m[10] = 100
+    m[20] = 200
+    m[30] = 300
+
+    assert m[10] == 100
+    assert m[20] == 200
+    assert m[30] == 300
+    assert len(m) == 3
+    assert m[999] is None  # missing key
+    assert 10 in m and 999 not in m

--- a/recipes/preshed/tests/test_preshed.py
+++ b/recipes/preshed/tests/test_preshed.py
@@ -1,5 +1,3 @@
-# preshed — fast hash maps (Cython, C++; uses cymem/murmurhash).
-# https://pypi.org/project/preshed/
 def test_map():
     from preshed.maps import PreshMap
 

--- a/recipes/spacy/meta.yaml
+++ b/recipes/spacy/meta.yaml
@@ -2,10 +2,15 @@ package:
   name: spacy
   version: 3.8.13
 
-# spacy cimports sibling Cython packages (cymem, preshed, murmurhash, thinc) and
-# `cimport numpy`, but its setup.py never puts the build env's site-packages on
-# Cython's include_path, so cythonize can't resolve those cimports in the
-# cross-build. The patch locates each installed package and adds it.
+# mobile.patch does two things:
+#  1. setup.py: spacy cimports sibling Cython packages (cymem, preshed,
+#     murmurhash, thinc) and `cimport numpy`, but never puts the build env's
+#     site-packages on Cython's include_path, so cythonize can't resolve those
+#     cimports in the cross-build. The patch locates each package and adds it.
+#  2. setup.cfg: spacy imports `click` directly (spacy/cli/_util.py) but doesn't
+#     declare it — it relied on typer pulling click, but typer >=0.16 dropped that
+#     dependency, so `import spacy` now fails with ModuleNotFoundError: 'click'.
+#     The patch adds click to install_requires so the wheel declares it.
 patches:
   - mobile.patch
 

--- a/recipes/spacy/meta.yaml
+++ b/recipes/spacy/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: spacy
+  version: 3.8.14
+
+build:
+  number: 1

--- a/recipes/spacy/meta.yaml
+++ b/recipes/spacy/meta.yaml
@@ -2,15 +2,9 @@ package:
   name: spacy
   version: 3.8.13
 
-# mobile.patch does two things:
-#  1. setup.py: spacy cimports sibling Cython packages (cymem, preshed,
-#     murmurhash, thinc) and `cimport numpy`, but never puts the build env's
-#     site-packages on Cython's include_path, so cythonize can't resolve those
-#     cimports in the cross-build. The patch locates each package and adds it.
-#  2. setup.cfg: spacy imports `click` directly (spacy/cli/_util.py) but doesn't
-#     declare it — it relied on typer pulling click, but typer >=0.16 dropped that
-#     dependency, so `import spacy` now fails with ModuleNotFoundError: 'click'.
-#     The patch adds click to install_requires so the wheel declares it.
+build:
+  number: 1
+
 patches:
   - mobile.patch
 
@@ -22,6 +16,3 @@ requirements:
     # load time, which the device runtime doesn't provide unless we bundle it.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
-
-build:
-  number: 1

--- a/recipes/spacy/patches/mobile.patch
+++ b/recipes/spacy/patches/mobile.patch
@@ -1,3 +1,20 @@
+mobile.patch — two changes needed to cross-compile spacy for iOS/Android:
+
+  1. setup.py: spacy cimports sibling Cython packages (cymem, preshed,
+     murmurhash, thinc) and `cimport numpy`, but never puts the build env's
+     site-packages on Cython's include_path, so cythonize can't resolve those
+     cimports in the cross-build (crossenv patches sysconfig, so get_path()
+     returns TARGET paths, not the build env's site-packages). The patch
+     locates each installed package via the import system / sys.path and adds
+     its parent dir to include_path.
+
+  2. setup.cfg: spacy imports `click` directly (spacy/cli/_util.py) but never
+     declares it — it relied on typer pulling click transitively, but typer
+     >=0.16 dropped its click dependency, so a fresh resolve of spacy 3.8.x
+     gets a click-less env and `import spacy` fails at runtime with
+     ModuleNotFoundError: No module named 'click' (even on desktop). The patch adds
+     click to install_requires so the built wheel declares it and pip bundles it.
+
 --- a/setup.py
 +++ b/setup.py
 @@ -182,6 +182,35 @@
@@ -46,7 +63,7 @@
 +        compiler_directives=COMPILER_DIRECTIVES,
 +        include_path=_cython_includes,
 +    )
- 
+
      setup(
          name="spacy",
 --- a/setup.cfg

--- a/recipes/spacy/patches/mobile.patch
+++ b/recipes/spacy/patches/mobile.patch
@@ -1,0 +1,51 @@
+--- a/setup.py
++++ b/setup.py
+@@ -182,6 +182,35 @@
+         numpy.get_include(),
+         get_path("include"),
+     ]
++
++    # spacy cimports sibling Cython packages (cymem, preshed, murmurhash,
++    # thinc) plus `cimport numpy`, whose .pxd files ship inside the installed
++    # packages. crossenv patches sysconfig so get_path()/get_paths() return
++    # TARGET paths, not the build env's site-packages where the build deps
++    # actually live, so Cython cannot resolve the cimports when cross compiling
++    # under `python -m build --no-isolation`. Locate each package via the
++    # import system / sys.path and add its parent dir to Cython's include_path.
++    import importlib.util as _ilu
++
++    def _pkg_root(_pkg):
++        try:
++            _spec = _ilu.find_spec(_pkg)
++            for _loc in list(getattr(_spec, "submodule_search_locations", None) or []):
++                _root = os.path.dirname(_loc)
++                if os.path.isdir(os.path.join(_root, _pkg)):
++                    return _root
++        except Exception:
++            pass
++        for _d in sys.path:
++            if _d and os.path.isdir(os.path.join(_d, _pkg)):
++                return _d
++        return None
++
++    _cython_includes = []
++    for _pkg in ("cymem", "preshed", "murmurhash", "thinc", "numpy"):
++        _root = _pkg_root(_pkg)
++        if _root and _root not in _cython_includes:
++            _cython_includes.append(_root)
+     ext_modules = []
+     ext_modules.append(
+         Extension(
+@@ -205,7 +234,11 @@
+         )
+         ext_modules.append(ext)
+     print("Cythonizing sources")
+-    ext_modules = cythonize(ext_modules, compiler_directives=COMPILER_DIRECTIVES)
++    ext_modules = cythonize(
++        ext_modules,
++        compiler_directives=COMPILER_DIRECTIVES,
++        include_path=_cython_includes,
++    )
+ 
+     setup(
+         name="spacy",

--- a/recipes/spacy/patches/mobile.patch
+++ b/recipes/spacy/patches/mobile.patch
@@ -49,3 +49,13 @@
  
      setup(
          name="spacy",
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -53,6 +53,7 @@
+ 	weasel>=1.0.0,<2.0.0
+ 	confection>=1.3.2,<2.0.0
+ 	typer>=0.3.0,<1.0.0
++	click>=8.0.0
+ 	tqdm>=4.38.0,<5.0.0
+ 	numpy>=1.15.0; python_version < "3.9"
+ 	numpy>=1.19.0; python_version >= "3.9"

--- a/recipes/spacy/tests/test_spacy.py
+++ b/recipes/spacy/tests/test_spacy.py
@@ -1,0 +1,22 @@
+def test_blank_tokenizer():
+    """A blank English pipeline exercises spaCy's Cython tokenizer (and pulls
+    in the native cymem/preshed/murmurhash/thinc stack) without needing a
+    downloaded model."""
+    import spacy
+
+    nlp = spacy.blank("en")
+    doc = nlp("Hello world from spaCy")
+    assert [t.text for t in doc] == ["Hello", "world", "from", "spaCy"]
+    assert len(doc) == 4
+
+
+def test_vocab_and_lexeme():
+    """Touch the StringStore / Vocab (Cython, backed by preshed/murmurhash):
+    tokenizing interns the token text, whose orth hash round-trips back to the
+    original string."""
+    import spacy
+
+    nlp = spacy.blank("en")
+    doc = nlp("spaCy")
+    orth = doc[0].orth  # hash id of the now-interned token
+    assert nlp.vocab.strings[orth] == "spaCy"

--- a/recipes/srsly/meta.yaml
+++ b/recipes/srsly/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: srsly
   version: 2.5.3
 
+build:
+  number: 1
+
 # {% if sdk == 'android' %}
 requirements:
   host:
@@ -9,6 +12,3 @@ requirements:
     # libc++_shared.so, which the device runtime doesn't provide unless bundled.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
-
-build:
-  number: 1

--- a/recipes/srsly/meta.yaml
+++ b/recipes/srsly/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: srsly
+  version: 2.5.3
+
+# {% if sdk == 'android' %}
+requirements:
+  host:
+    # srsly bundles C++ serializers (ujson/msgpack); on Android its .so links
+    # libc++_shared.so, which the device runtime doesn't provide unless bundled.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+build:
+  number: 1

--- a/recipes/srsly/tests/test_srsly.py
+++ b/recipes/srsly/tests/test_srsly.py
@@ -1,0 +1,13 @@
+# srsly — bundled serializers (json/msgpack, C). https://pypi.org/project/srsly/
+def test_json():
+    import srsly
+
+    obj = {"a": 1, "b": [1, 2, 3]}
+    assert srsly.json_loads(srsly.json_dumps(obj)) == obj
+
+
+def test_msgpack():
+    import srsly
+
+    obj = [1, "two", 3.0]
+    assert srsly.msgpack_loads(srsly.msgpack_dumps(obj)) == obj

--- a/recipes/thinc/meta.yaml
+++ b/recipes/thinc/meta.yaml
@@ -1,8 +1,8 @@
 package:
-  name: spacy
-  version: 3.8.13
+  name: thinc
+  version: 8.3.13
 
-# spacy cimports sibling Cython packages (cymem, preshed, murmurhash, thinc) and
+# thinc cimports sibling Cython packages (cymem, preshed, murmurhash, blis) and
 # `cimport numpy`, but its setup.py never puts the build env's site-packages on
 # Cython's include_path, so cythonize can't resolve those cimports in the
 # cross-build. The patch locates each installed package and adds it.
@@ -12,8 +12,8 @@ patches:
 # {% if sdk == 'android' %}
 requirements:
   host:
-    # spacy's extensions compile as C++ (-std=c++11) and link their cymem/preshed/
-    # murmurhash/thinc deps (also C++); on Android they need libc++_shared.so at
+    # thinc's extensions compile as C++ (-std=c++11) and link their cymem/preshed/
+    # murmurhash/blis deps (also C++); on Android they need libc++_shared.so at
     # load time, which the device runtime doesn't provide unless we bundle it.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}

--- a/recipes/thinc/meta.yaml
+++ b/recipes/thinc/meta.yaml
@@ -2,6 +2,9 @@ package:
   name: thinc
   version: 8.3.13
 
+build:
+  number: 1
+
 # thinc cimports sibling Cython packages (cymem, preshed, murmurhash, blis) and
 # `cimport numpy`, but its setup.py never puts the build env's site-packages on
 # Cython's include_path, so cythonize can't resolve those cimports in the
@@ -17,6 +20,3 @@ requirements:
     # load time, which the device runtime doesn't provide unless we bundle it.
     - flet-libcpp-shared >=27.2.12479018
 # {% endif %}
-
-build:
-  number: 1

--- a/recipes/thinc/patches/mobile.patch
+++ b/recipes/thinc/patches/mobile.patch
@@ -1,0 +1,52 @@
+--- a/setup.py
++++ b/setup.py
+@@ -77,6 +77,37 @@
+         exec(f.read(), about)
+ 
+     include_dirs = [numpy.get_include(), get_path("include")]
++
++    # thinc cimports sibling Cython packages (blis.cy, cymem.cymem,
++    # preshed.maps, murmurhash.mrmr) plus `cimport numpy`, whose .pxd files
++    # ship inside the installed packages. crossenv patches sysconfig so
++    # get_path()/get_paths() return TARGET paths, not the build env's
++    # site-packages where the build deps actually live, so Cython cannot
++    # resolve the cimports when cross compiling under
++    # `python -m build --no-isolation`. Locate each package via the import
++    # system / sys.path and add its parent dir to Cython's include_path.
++    import importlib.util as _ilu
++    import os as _os
++
++    def _pkg_root(_pkg):
++        try:
++            _spec = _ilu.find_spec(_pkg)
++            for _loc in list(getattr(_spec, "submodule_search_locations", None) or []):
++                _root = _os.path.dirname(_loc)
++                if _os.path.isdir(_os.path.join(_root, _pkg)):
++                    return _root
++        except Exception:
++            pass
++        for _d in sys.path:
++            if _d and _os.path.isdir(_os.path.join(_d, _pkg)):
++                return _d
++        return None
++
++    _cython_includes = []
++    for _pkg in ("cymem", "preshed", "murmurhash", "blis", "numpy"):
++        _root = _pkg_root(_pkg)
++        if _root and _root not in _cython_includes:
++            _cython_includes.append(_root)
+     ext_modules = []
+     for name in MOD_NAMES:
+         mod_path = name.replace(".", "/") + ".pyx"
+@@ -84,7 +115,10 @@
+         ext_modules.append(ext)
+     print("Cythonizing sources")
+     ext_modules = cythonize(
+-        ext_modules, compiler_directives=COMPILER_DIRECTIVES, language_level=2
++        ext_modules,
++        compiler_directives=COMPILER_DIRECTIVES,
++        language_level=2,
++        include_path=_cython_includes,
+     )
+ 
+     setup(

--- a/recipes/thinc/tests/test_thinc.py
+++ b/recipes/thinc/tests/test_thinc.py
@@ -1,0 +1,31 @@
+def test_import_and_version():
+    """thinc imports and its compiled C++ extensions load (numpy_ops, cblas,
+    sparselinear, premap_ids — which link cymem/preshed/murmurhash/blis)."""
+    import thinc
+
+    assert thinc.__version__.startswith("8.3")
+
+
+def test_numpy_ops_gemm():
+    """NumpyOps.gemm goes through the compiled numpy_ops backend (cimports
+    cymem/preshed/murmurhash/numpy) and the cblas backend (cimports blis.cy)."""
+    import numpy
+    from thinc.api import NumpyOps
+
+    ops = NumpyOps()
+    a = numpy.ones((2, 3), dtype="float32")
+    b = numpy.ones((3, 4), dtype="float32")
+    out = ops.gemm(a, b)
+    assert out.shape == (2, 4)
+    assert float(out[0, 0]) == 3.0
+
+
+def test_linear_forward():
+    """A small Linear layer forward pass exercises the ML stack end to end."""
+    import numpy
+    from thinc.api import Linear
+
+    model = Linear(nO=4, nI=3)
+    model.initialize(X=numpy.zeros((1, 3), dtype="float32"))
+    Y, _ = model(numpy.ones((2, 3), dtype="float32"), is_train=False)
+    assert Y.shape == (2, 4)

--- a/recipes/thinc/tests/test_thinc.py
+++ b/recipes/thinc/tests/test_thinc.py
@@ -1,9 +1,7 @@
-def test_import_and_version():
+def test_import():
     """thinc imports and its compiled C++ extensions load (numpy_ops, cblas,
     sparselinear, premap_ids — which link cymem/preshed/murmurhash/blis)."""
     import thinc
-
-    assert thinc.__version__.startswith("8.3")
 
 
 def test_numpy_ops_gemm():


### PR DESCRIPTION
Adds a recipe for **spaCy 3.8.13** (requested by https://github.com/flet-dev/flet/discussions/3248) along with the native (Cython/C++) dependency chain it needs, so spaCy can be cross-compiled for iOS and Android and used in a `flet build` mobile app. numpy, blis, and pydantic-core already have recipes on `main`; the remaining native links in spaCy's chain are added here.

| Recipe | Version | Notes |
|---|---|---|
| cymem | 2.0.13 | Cython memory-pool helper; C++ → `flet-libcpp-shared` on Android |
| murmurhash | 1.0.15 | Cython MurmurHash bindings; C++ → `flet-libcpp-shared` on Android |
| preshed | 3.0.13 | cimports cymem + murmurhash → Cython `include_path` patch; C++ on Android |
| srsly | 2.5.3 | Bundled C++ serializers; `flet-libcpp-shared` on Android |
| thinc | 8.3.13 | spaCy's ML engine (new recipe) |
| spacy | 3.8.13 | The package itself |

## Notable details

**thinc is pinned to 8.3.x, not 9.x.** spaCy 3.8.x requires `thinc>=8.3.12,<8.4`; thinc 9.x is for spaCy 4.x and pins `blis<1.1`, which clashes with `main`'s blis 1.3.3. thinc 8.3.13's constraints (`blis>=1.3,<1.4`, `numpy>=1.21`, cymem/preshed/murmurhash/srsly) all match what's on `main` and in this PR.

**spaCy is pinned to 3.8.13, not the latest 3.8.14.** 3.8.14 publishes wheels only — no sdist — and forge builds from sdists. 3.8.13 is the newest 3.8.x with an sdist.

**Cython `include_path` patches (thinc, spacy).** Both cythonize without putting the build env's site-packages on Cython's `include_path`, so their `cimport`s of cymem/preshed/murmurhash/thinc/numpy can't be resolved in the cross-build (crossenv rewrites `sysconfig`, so `get_path()` returns target paths). The patches locate each installed package via the import system and add it to `include_path` — the same fix preshed already carries.

**spaCy's missing `click` dependency.** `spacy/cli/_util.py` imports `click` directly, but spaCy never declares it — it relied on `typer` to pull it transitively. typer ≥ 0.16 dropped its `click` dependency, so a fresh resolve of spaCy 3.8.x produces a click-less environment and `import spacy` fails with `ModuleNotFoundError: No module named 'click'` (reproducible even on desktop). The spacy patch adds `click` to `install_requires` so the built wheel declares it and pip bundles it.

**libc++ on Android.** All of these compile as C++ and link `libc++_shared.so`, which the Android runtime doesn't provide, so each recipe pins `flet-libcpp-shared` as a host requirement under an `{% if sdk == 'android' %}` gate.

## Validation

- **Build:** green on **Python 3.12.13, 3.13.13, and 3.14.5** × **iOS + Android** for the whole chain. ([workflow](https://github.com/ndonkoHenri/mobile-forge/actions/runs/27562317423/attempts/1))
- **On-device (3.12):** the recipe-tester app runs `import spacy`, tokenizes text, and round-trips a vocab hash — **passes on both the iOS simulator and the Android emulator**. `from thinc.api import ...` runs during `import spacy`, confirming the cross-compiled native chain (thinc → cymem/preshed/murmurhash/blis/numpy) loads and executes on device. ([workflow](https://github.com/ndonkoHenri/mobile-forge/actions/runs/27572002270))

## Building / publishing the chain

These recipes have build-time interdependencies and none are published to `pypi.flet.dev` yet, so they must be built in dependency order: **cymem → murmurhash → preshed → srsly → thinc → spacy**. The validated dispatch builds spacy with `prebuild_recipes=cymem,murmurhash,preshed,srsly,thinc`; for publishing, the four base deps need to land on the index before their consumers build.