### PR TITLE
recipe: polars 1.33.0

### DIFF
--- a/recipes/polars/meta.yaml
+++ b/recipes/polars/meta.yaml
@@ -1,6 +1,11 @@
 package:
   name: polars
   version: 1.33.0
+  # polars uses std::sync::atomic::AtomicU64, which is absent on 32-bit ARM
+  # (arm-linux-androideabi has no 64-bit atomics), so armeabi-v7a fails to build;
+  # upstream ships no 32-bit-ARM wheels. 32-bit x86 builds fine (has cmpxchg8b),
+  # so only armeabi-v7a is excluded. Only builds on Python < 3.13 anyway.
+  excluded_arches: [armeabi-v7a]
 
 build:
   number: 1

--- a/recipes/polars/meta.yaml
+++ b/recipes/polars/meta.yaml
@@ -11,7 +11,9 @@ build:
   number: 1
 
 # Cross-build fixes: Rust targets on the pinned nightly, drop the desktop-only
-# clipboard/arboard feature, and use the system allocator on iOS (jemalloc's
-# config.sub rejects the iOS triple). Rationale is in the header of mobile.patch.
+# clipboard/arboard feature, and use the system allocator on iOS + Android
+# instead of jemalloc (jemalloc's config.sub rejects the iOS triple, and on
+# Android it calls a seccomp-banned raw open(2) that SIGSYS-kills import).
+# Rationale is in the header of mobile.patch.
 patches:
   - mobile.patch

--- a/recipes/polars/meta.yaml
+++ b/recipes/polars/meta.yaml
@@ -5,7 +5,8 @@ package:
 build:
   number: 1
 
-# Adds the iOS/Android Rust targets to polars' pinned nightly toolchain so the
-# cross-build can find the target std. See the header in patches/mobile.patch.
+# Cross-build fixes: Rust targets on the pinned nightly, drop the desktop-only
+# clipboard/arboard feature, and use the system allocator on iOS (jemalloc's
+# config.sub rejects the iOS triple). Rationale is in the header of mobile.patch.
 patches:
   - mobile.patch

--- a/recipes/polars/meta.yaml
+++ b/recipes/polars/meta.yaml
@@ -1,0 +1,3 @@
+package:
+  name: polars
+  version: 1.33.0

--- a/recipes/polars/meta.yaml
+++ b/recipes/polars/meta.yaml
@@ -1,3 +1,11 @@
 package:
   name: polars
   version: 1.33.0
+
+build:
+  number: 1
+
+# Adds the iOS/Android Rust targets to polars' pinned nightly toolchain so the
+# cross-build can find the target std. See the header in patches/mobile.patch.
+patches:
+  - mobile.patch

--- a/recipes/polars/patches/mobile.patch
+++ b/recipes/polars/patches/mobile.patch
@@ -37,7 +37,7 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
  channel = "nightly-2025-08-29"
 +targets = [
 +    "aarch64-linux-android",
-+    "armv7-linux-androideabi",
++    "arm-linux-androideabi",
 +    "i686-linux-android",
 +    "x86_64-linux-android",
 +    "aarch64-apple-ios",
@@ -51,7 +51,7 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
  channel = "nightly-2025-08-29"
 +targets = [
 +    "aarch64-linux-android",
-+    "armv7-linux-androideabi",
++    "arm-linux-androideabi",
 +    "i686-linux-android",
 +    "x86_64-linux-android",
 +    "aarch64-apple-ios",

--- a/recipes/polars/patches/mobile.patch
+++ b/recipes/polars/patches/mobile.patch
@@ -1,15 +1,24 @@
-mobile.patch — install the cross-compile targets for polars' pinned Rust toolchain.
+mobile.patch — two changes to cross-compile polars for iOS/Android.
 
-polars pins nightly-2025-08-29 via rust-toolchain.toml (its `nightly` cargo
-feature is on by default and uses nightly-gated SIMD intrinsics), so cargo
-switches to that nightly when building py-polars. CI installs the iOS/Android
-Rust targets onto the *stable* toolchain only (dtolnay/rust-toolchain@stable
-with matrix.rust_targets), so the pinned nightly has no target std library and
-the cross-build fails with `error[E0463]: can't find crate for core`.
+1. rust-toolchain.toml (workspace root + py-polars/): install the cross-compile
+   targets on polars' pinned Rust toolchain.
 
-Adding the mobile targets to rust-toolchain.toml makes rustup install them when
-it provisions the pinned nightly on first use. Both copies are patched (the
-workspace root and py-polars/) since cargo uses whichever is nearest its CWD.
+   polars pins nightly-2025-08-29 (its `nightly` cargo feature is on by default
+   and uses nightly-gated SIMD intrinsics), so cargo switches to that nightly
+   when building py-polars. CI installs the iOS/Android Rust targets onto the
+   *stable* toolchain only (dtolnay/rust-toolchain@stable + matrix.rust_targets),
+   so the pinned nightly has no target std and the cross-build fails with
+   `error[E0463]: can't find crate for core`. Adding the targets to the toml
+   makes rustup install them when it provisions the nightly. Both copies are
+   patched since cargo uses whichever is nearest its CWD.
+
+2. py-polars/Cargo.toml + crates/polars-python/Cargo.toml: drop `clipboard` from
+   the `full` feature. The clipboard feature pulls `arboard`, a desktop-only
+   clipboard crate with no Android/iOS backend (it fails to compile:
+   `cannot find type Clipboard in module platform`, and on iOS drags in x11rb /
+   core-foundation). polars' default features are `["full", "nightly"]`, so
+   `full` is what enables it. Removing it from both `full` definitions drops the
+   whole arboard subtree (verified clean via `cargo tree --target`).
 
 --- a/rust-toolchain.toml
 +++ b/rust-toolchain.toml
@@ -39,3 +48,23 @@ workspace root and py-polars/) since cargo uses whichever is nearest its CWD.
 +    "aarch64-apple-ios-sim",
 +    "x86_64-apple-ios",
 +]
+--- a/py-polars/Cargo.toml
++++ b/py-polars/Cargo.toml
+@@ -92,7 +92,6 @@
+   "csv",
+   "polars_cloud_client",
+   "object",
+-  "clipboard",
+   "sql",
+   "trigonometry",
+   "parquet",
+--- a/crates/polars-python/Cargo.toml
++++ b/crates/polars-python/Cargo.toml
+@@ -258,7 +258,6 @@
+   "avro",
+   "csv",
+   "cloud",
+-  "clipboard",
+ ]
+ 
+ optimizations = [

--- a/recipes/polars/patches/mobile.patch
+++ b/recipes/polars/patches/mobile.patch
@@ -1,4 +1,4 @@
-mobile.patch — two changes to cross-compile polars for iOS/Android.
+mobile.patch — three changes to cross-compile polars for iOS/Android.
 
 1. rust-toolchain.toml (workspace root + py-polars/): install the cross-compile
    targets on polars' pinned Rust toolchain.
@@ -19,6 +19,16 @@ mobile.patch — two changes to cross-compile polars for iOS/Android.
    core-foundation). polars' default features are `["full", "nightly"]`, so
    `full` is what enables it. Removing it from both `full` definitions drops the
    whole arboard subtree (verified clean via `cargo tree --target`).
+
+3. crates/polars-python/src/c_api/allocator.rs + Cargo.toml: use the system
+   allocator on iOS instead of jemalloc. polars selects tikv-jemallocator for
+   `unix && !macos` (which includes iOS), but jemalloc's autotools `config.sub`
+   rejects the `aarch64-apple-ios-sim` triple, so its build.rs panics
+   (`config.sub aarch64-apple-ios-sim failed`). Excluding `target_os = "ios"`
+   from both the jemalloc dependency cfg and the `#[global_allocator]` cfg leaves
+   no custom allocator on iOS, so Rust falls back to the system allocator (no
+   extra C build). Android keeps jemalloc (its triple is accepted); macOS is
+   unaffected.
 
 --- a/rust-toolchain.toml
 +++ b/rust-toolchain.toml
@@ -60,6 +70,15 @@ mobile.patch — two changes to cross-compile polars for iOS/Android.
    "parquet",
 --- a/crates/polars-python/Cargo.toml
 +++ b/crates/polars-python/Cargo.toml
+@@ -55,7 +55,7 @@
+ mimalloc = { version = "0.1", default-features = false }
+ 
+ # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
+-[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten")))'.dependencies]
++[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(target_os = "ios")))'.dependencies]
+ tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"] }
+ 
+ [target.'cfg(all(target_family = "unix", target_os = "macos"))'.dependencies]
 @@ -258,7 +258,6 @@
    "avro",
    "csv",
@@ -68,3 +87,13 @@ mobile.patch — two changes to cross-compile polars for iOS/Android.
  ]
  
  optimizations = [
+--- a/crates/polars-python/src/c_api/allocator.rs
++++ b/crates/polars-python/src/c_api/allocator.rs
+@@ -2,6 +2,7 @@
+     not(feature = "default_alloc"),
+     target_family = "unix",
+     not(target_os = "emscripten"),
++    not(target_os = "ios"),
+ ))]
+ #[global_allocator]
+ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/recipes/polars/patches/mobile.patch
+++ b/recipes/polars/patches/mobile.patch
@@ -10,7 +10,8 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
    so the pinned nightly has no target std and the cross-build fails with
    `error[E0463]: can't find crate for core`. Adding the targets to the toml
    makes rustup install them when it provisions the nightly. Both copies are
-   patched since cargo uses whichever is nearest its CWD.
+   patched since cargo uses whichever is nearest its CWD. (armeabi-v7a uses the
+   `arm-linux-androideabi` triple, matching forge/CI — not `armv7-...`.)
 
 2. py-polars/Cargo.toml + crates/polars-python/Cargo.toml: drop `clipboard` from
    the `full` feature. The clipboard feature pulls `arboard`, a desktop-only
@@ -21,14 +22,21 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
    whole arboard subtree (verified clean via `cargo tree --target`).
 
 3. crates/polars-python/src/c_api/allocator.rs + Cargo.toml: use the system
-   allocator on iOS instead of jemalloc. polars selects tikv-jemallocator for
-   `unix && !macos` (which includes iOS), but jemalloc's autotools `config.sub`
-   rejects the `aarch64-apple-ios-sim` triple, so its build.rs panics
-   (`config.sub aarch64-apple-ios-sim failed`). Excluding `target_os = "ios"`
-   from both the jemalloc dependency cfg and the `#[global_allocator]` cfg leaves
-   no custom allocator on iOS, so Rust falls back to the system allocator (no
-   extra C build). Android keeps jemalloc (its triple is accepted); macOS is
-   unaffected.
+   allocator (not jemalloc) on BOTH iOS and Android. jemalloc is the source of
+   two separate mobile failures:
+     - iOS: tikv-jemalloc-sys's autotools `config.sub` rejects the
+       `aarch64-apple-ios-sim` triple, so its build.rs panics at build time.
+     - Android: jemalloc opens `/proc/sys/vm/overcommit_memory` at init via a
+       raw `syscall(SYS_open, ...)` (x86_64 syscall #2), which Android's seccomp
+       policy disallows -> `import polars` is SIGSYS-killed on the x86_64
+       emulator (and on any x86_64 android). On arm64 there is no `open` syscall
+       so it is latent, but using the system allocator everywhere keeps the
+       tested config (x86_64) identical to the shipped one (arm64).
+   polars selects tikv-jemallocator for `unix && !macos`; excluding
+   `target_os = "ios"` and `target_os = "android"` from both the dependency cfg
+   and the `#[global_allocator]` cfg leaves no custom allocator on mobile, so
+   Rust uses the system allocator (Android's is scudo; iOS's is libmalloc) -- no
+   extra C build, no banned syscalls. Desktop (macOS/Linux/Windows) is unchanged.
 
 --- a/rust-toolchain.toml
 +++ b/rust-toolchain.toml
@@ -75,7 +83,7 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
  
  # Feature background_threads is unsupported on MacOS (https://github.com/jemalloc/jemalloc/issues/843).
 -[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten")))'.dependencies]
-+[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(target_os = "ios")))'.dependencies]
++[target.'cfg(all(target_family = "unix", not(target_os = "macos"), not(target_os = "emscripten"), not(target_os = "ios"), not(target_os = "android")))'.dependencies]
  tikv-jemallocator = { version = "0.6.0", features = ["disable_initial_exec_tls", "background_threads"] }
  
  [target.'cfg(all(target_family = "unix", target_os = "macos"))'.dependencies]
@@ -89,11 +97,12 @@ mobile.patch — three changes to cross-compile polars for iOS/Android.
  optimizations = [
 --- a/crates/polars-python/src/c_api/allocator.rs
 +++ b/crates/polars-python/src/c_api/allocator.rs
-@@ -2,6 +2,7 @@
+@@ -2,6 +2,8 @@
      not(feature = "default_alloc"),
      target_family = "unix",
      not(target_os = "emscripten"),
 +    not(target_os = "ios"),
++    not(target_os = "android"),
  ))]
  #[global_allocator]
  static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;

--- a/recipes/polars/patches/mobile.patch
+++ b/recipes/polars/patches/mobile.patch
@@ -1,0 +1,41 @@
+mobile.patch — install the cross-compile targets for polars' pinned Rust toolchain.
+
+polars pins nightly-2025-08-29 via rust-toolchain.toml (its `nightly` cargo
+feature is on by default and uses nightly-gated SIMD intrinsics), so cargo
+switches to that nightly when building py-polars. CI installs the iOS/Android
+Rust targets onto the *stable* toolchain only (dtolnay/rust-toolchain@stable
+with matrix.rust_targets), so the pinned nightly has no target std library and
+the cross-build fails with `error[E0463]: can't find crate for core`.
+
+Adding the mobile targets to rust-toolchain.toml makes rustup install them when
+it provisions the pinned nightly on first use. Both copies are patched (the
+workspace root and py-polars/) since cargo uses whichever is nearest its CWD.
+
+--- a/rust-toolchain.toml
++++ b/rust-toolchain.toml
+@@ -1,2 +1,11 @@
+ [toolchain]
+ channel = "nightly-2025-08-29"
++targets = [
++    "aarch64-linux-android",
++    "armv7-linux-androideabi",
++    "i686-linux-android",
++    "x86_64-linux-android",
++    "aarch64-apple-ios",
++    "aarch64-apple-ios-sim",
++    "x86_64-apple-ios",
++]
+--- a/py-polars/rust-toolchain.toml
++++ b/py-polars/rust-toolchain.toml
+@@ -1,2 +1,11 @@
+ [toolchain]
+ channel = "nightly-2025-08-29"
++targets = [
++    "aarch64-linux-android",
++    "armv7-linux-androideabi",
++    "i686-linux-android",
++    "x86_64-linux-android",
++    "aarch64-apple-ios",
++    "aarch64-apple-ios-sim",
++    "x86_64-apple-ios",
++]

--- a/recipes/polars/tests/test_polars.py
+++ b/recipes/polars/tests/test_polars.py
@@ -1,0 +1,17 @@
+def test_dataframe_aggregation():
+    """Construct a small DataFrame and aggregate via polars."""
+    import polars as pl
+
+    df = pl.DataFrame(
+        {
+            "category": ["a", "b", "a", "b", "a"],
+            "value": [1, 2, 3, 4, 5],
+        }
+    )
+
+    result = df.group_by("category").agg(pl.col("value").sum()).sort("category")
+    rows = result.to_dicts()
+
+    # a: 1+3+5=9, b: 2+4=6
+    assert rows[0] == {"category": "a", "value": 9}
+    assert rows[1] == {"category": "b", "value": 6}

--- a/src/forge/__main__.py
+++ b/src/forge/__main__.py
@@ -154,6 +154,17 @@ def main():
                     sdk_version=sdk_version,
                     arch=arch,
                 )
+
+                # Skip arches the recipe declares it can't build (e.g. a library
+                # with no 32-bit support listing [armeabi-v7a, x86]). Other arches
+                # of the same platform still build.
+                if arch in package.meta["package"].get("excluded_arches", []):
+                    print(
+                        f"Skipping {arch}: {package.name} lists it in "
+                        f"package.excluded_arches"
+                    )
+                    continue
+
                 cross_venv = CrossVEnv(sdk=sdk, sdk_version=sdk_version, arch=arch)
                 builder = package.builder(cross_venv)
                 success = builder.build(clean=first)

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -378,6 +378,18 @@ class Builder(ABC):
             # 16 KB page alignment required by Google Play (Android 15+)
             cargo_ldflags += " -C link-arg=-z -C link-arg=max-page-size=16384"
 
+            # NDK r23+ removed libgcc.a (unwinding moved to libunwind), but some
+            # Rust toolchains still emit `-lgcc` on the link line -- e.g. recipes
+            # that pin an older nightly via rust-toolchain.toml (polars). The
+            # current stable target spec no longer does, so most recipes are
+            # unaffected. Drop a libgcc.a *linker script* that redirects to
+            # libunwind (already linked) onto the search path so `-lgcc` resolves
+            # instead of failing with `ld.lld: error: unable to find library -lgcc`.
+            libgcc_shim = self.build_path / ".libgcc-shim"
+            libgcc_shim.mkdir(parents=True, exist_ok=True)
+            (libgcc_shim / "libgcc.a").write_text("INPUT(-lunwind)\n")
+            cargo_ldflags += f" -L{libgcc_shim}"
+
         if self.cross_venv.sdk != "android":
             # Replace any hard-coded reference to -isysroot <sysroot> with the actual reference
             ldflags = re.sub(

--- a/src/forge/schema/meta-schema.yaml
+++ b/src/forge/schema/meta-schema.yaml
@@ -23,8 +23,20 @@ properties:
         minItems: 1
         uniqueItems: true
         description: >-
-          Optional list of supported target platforms. 
+          Optional list of supported target platforms.
           Defaults to all platforms if not specified.
+      excluded_arches:
+        type: array
+        items:
+          type: string
+          enum: [arm64-v8a, armeabi-v7a, x86_64, x86, arm64]
+        uniqueItems: true
+        description: >-
+          Optional list of target architectures to skip for this package
+          (e.g. [armeabi-v7a, x86] for a library with no 32-bit support).
+          Other arches of the same platform still build. The 32-bit android
+          arches only build on Python < 3.13, so excluding them is a no-op on
+          newer interpreters.
     additionalProperties: false
 
   source:


### PR DESCRIPTION
Adds a cross-compiled **polars 1.33.0** recipe for iOS + Android (requested by https://github.com/flet-dev/flet/discussions/3177). polars is a heavy Rust/maturin (PyO3) project, so this surfaced several cross-build and on-device issues; the recipe carries a 3-part `mobile.patch` (fully documented in its header), and two small **general-purpose forge additions** that any Rust/native recipe can use.

**Version note:** 1.33.x is the **last polars release with a buildable sdist** — from 1.34.0 on, the PyPI sdist is a ~700 KB Python-only stub (no Rust source), so forge can't cross-compile it. 1.33.0 is pinned deliberately.

## Forge changes (general, reusable)

- **`src/forge/build.py`** — for Android Rust links, drop a `libgcc.a` linker script (`INPUT(-lunwind)`) on the cargo search path. NDK r23+ removed `libgcc.a`, but some toolchains (e.g. a recipe pinning an older nightly via `rust-toolchain.toml`) still emit `-lgcc`. Harmless for recipes that don't.
- **`src/forge/__main__.py` + `schema/meta-schema.yaml`** — new optional `package.excluded_arches`. Lets a recipe skip target arches it can't build while others still build. polars uses it for `armeabi-v7a`.

## Recipe (`recipes/polars/`)

`meta.yaml` pins 1.33.0, sets `excluded_arches: [armeabi-v7a]`, and applies `mobile.patch`, which does three things:
1. **rust-toolchain.toml** (root + py-polars/) — add the iOS/Android Rust targets to polars' pinned `nightly-2025-08-29` (CI only targets *stable*, so the cross-build hit `E0463: can't find crate for core`).
2. **drop the `clipboard` feature** — it pulls `arboard`, a desktop-only clipboard crate with no mobile backend.
3. **system allocator on iOS + Android** (not jemalloc). jemalloc caused *both* mobile failures: iOS — its `config.sub` rejects `aarch64-apple-ios-sim` (build-time panic); Android — it calls a seccomp-banned raw `open(2)` at init, SIGSYS-killing `import polars` on x86_64. Android's own allocator is scudo, so negligible impact.

`armeabi-v7a` (32-bit ARM) is excluded because polars uses `AtomicU64`, absent there; upstream ships no 32-bit-ARM wheels either. (Only builds on Python <3.13 anyway.)

## Validation

- **Build:** green on **Python 3.12 / 3.13 / 3.14 × iOS + Android** (all arches; armeabi-v7a skipped).
- **On-device:** the recipe-tester (`import polars` + a group_by/agg) **passes** on the Android emulator (3.12) and the iOS simulator (3.12).