### PR TITLE
recipe: pyzmq 27.1.0

### DIFF
--- a/recipes/pyzmq/meta.yaml
+++ b/recipes/pyzmq/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: pyzmq
+  version: 27.1.0
+
+build:
+  number: 1

--- a/recipes/pyzmq/meta.yaml
+++ b/recipes/pyzmq/meta.yaml
@@ -33,10 +33,15 @@ build:
       -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
       -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
       -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,max-page-size=16384
-      -DPython_EXECUTABLE={prefix}/bin/python{py_version_short}
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
       -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
       -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
 # {% else %}
+    # The `ninja` pip package crashes importing on the iOS crossenv python
+    # (sysconfig.get_preferred_scheme("user") -> 'posix_user' invalid on iOS),
+    # so use the Makefiles generator on iOS; scikit-build-core then never imports
+    # ninja. (Android keeps the Ninja generator, which works there.)
+    CMAKE_GENERATOR: Unix Makefiles
     CMAKE_ARGS: >-
       -DZMQ_PREFIX=bundled
       -DCMAKE_SYSTEM_NAME=iOS
@@ -44,7 +49,7 @@ build:
       -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
       -DCMAKE_OSX_ARCHITECTURES={{ arch }}
       -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
-      -DPython_EXECUTABLE={prefix}/bin/python{py_version_short}
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
       -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
       -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
 # {% endif %}

--- a/recipes/pyzmq/meta.yaml
+++ b/recipes/pyzmq/meta.yaml
@@ -37,6 +37,13 @@ build:
       -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
       -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
 # {% else %}
+    # Same bundled-libsodium ./configure cross issue as Android, but iOS has no
+    # forge {HOST_TRIPLET}. `<arch>-apple-ios` is accepted by libsodium's
+    # config.sub (arm64->aarch64-apple-ios, x86_64-apple-ios) and is always
+    # `!=` the macOS build triple (ios != darwin), so configure registers as
+    # cross. The actual simulator/device codegen comes from forge's iOS CC, not
+    # this triple (libsodium's .a is retargeted by CFLAGS/-isysroot).
+    CIBW_HOST_TRIPLET: "{{ arch }}-apple-ios"
     # The `ninja` pip package crashes importing on the iOS crossenv python
     # (sysconfig.get_preferred_scheme("user") -> 'posix_user' invalid on iOS),
     # so use the Makefiles generator on iOS; scikit-build-core then never imports

--- a/recipes/pyzmq/meta.yaml
+++ b/recipes/pyzmq/meta.yaml
@@ -2,5 +2,49 @@ package:
   name: pyzmq
   version: 27.1.0
 
+requirements:
+  build:
+    # pyzmq builds via scikit-build-core + CMake (+ Ninja generator); with
+    # `python -m build --no-isolation` these must be in the build venv.
+    - cmake
+    - ninja
+# {% if sdk == 'android' %}
+  host:
+    # pyzmq bundles + builds libzmq (C++); on Android the .so links
+    # libc++_shared.so, which the device runtime doesn't provide unless bundled.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
 build:
   number: 1
+  script_env:
+# {% if sdk == 'android' %}
+    # pyzmq adds `--host` to the bundled libsodium ./configure only when
+    # CMAKE_CROSSCOMPILING and CIBW_HOST_TRIPLET are set (it's wired for
+    # cibuildwheel); without it, libsodium's configure tries to run a target
+    # binary on the host and dies with "cannot run C compiled programs".
+    CIBW_HOST_TRIPLET: "{HOST_TRIPLET}"
+    CMAKE_ARGS: >-
+      -DZMQ_PREFIX=bundled
+      -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake
+      -DANDROID_ABI={ANDROID_ABI}
+      -DANDROID_NATIVE_API_LEVEL={ANDROID_API_LEVEL}
+      -DANDROID_STL=c++_shared
+      -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+      -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DPython_EXECUTABLE={prefix}/bin/python{py_version_short}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
+# {% else %}
+    CMAKE_ARGS: >-
+      -DZMQ_PREFIX=bundled
+      -DCMAKE_SYSTEM_NAME=iOS
+      -DCMAKE_OSX_SYSROOT={{ sdk }}
+      -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
+      -DCMAKE_OSX_ARCHITECTURES={{ arch }}
+      -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+      -DPython_EXECUTABLE={prefix}/bin/python{py_version_short}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
+# {% endif %}

--- a/recipes/pyzmq/tests/test_pyzmq.py
+++ b/recipes/pyzmq/tests/test_pyzmq.py
@@ -1,12 +1,3 @@
-def test_versions():
-    """The compiled backend (Cython over the bundled libzmq) loads and reports
-    sane versions."""
-    import zmq
-
-    assert zmq.zmq_version_info()[0] >= 4  # libzmq major
-    assert zmq.pyzmq_version_info()[0] >= 27  # pyzmq major
-
-
 def test_inproc_pair():
     """A PAIR socket over inproc:// exercises Context + Socket + send/recv through
     the compiled libzmq backend, without touching the network (no ports/sockets,

--- a/recipes/pyzmq/tests/test_pyzmq.py
+++ b/recipes/pyzmq/tests/test_pyzmq.py
@@ -1,0 +1,27 @@
+def test_versions():
+    """The compiled backend (Cython over the bundled libzmq) loads and reports
+    sane versions."""
+    import zmq
+
+    assert zmq.zmq_version_info()[0] >= 4  # libzmq major
+    assert zmq.pyzmq_version_info()[0] >= 27  # pyzmq major
+
+
+def test_inproc_pair():
+    """A PAIR socket over inproc:// exercises Context + Socket + send/recv through
+    the compiled libzmq backend, without touching the network (no ports/sockets,
+    so it's safe on a sandboxed emulator/simulator)."""
+    import zmq
+
+    ctx = zmq.Context()
+    sender = ctx.socket(zmq.PAIR)
+    receiver = ctx.socket(zmq.PAIR)
+    sender.bind("inproc://pyzmq-test")
+    receiver.connect("inproc://pyzmq-test")
+
+    sender.send(b"hello from pyzmq")
+    assert receiver.recv() == b"hello from pyzmq"
+
+    sender.close()
+    receiver.close()
+    ctx.term()

--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -497,6 +497,19 @@ class Builder(ABC):
             # Python_INCLUDE_DIR against a path that doesn't move with
             # crossenv relocation across python-build versions.
             "HOST_PYTHON_HOME": str(self.cross_venv.host_python_home),
+            # The host-runnable Python interpreter provided by crossenv: a
+            # wrapper script that runs the build-machine Python but reports
+            # the *target* sysconfig. Use this for CMake's -DPython_EXECUTABLE
+            # (FindPython's Interpreter component). Pointing at
+            # {prefix}/bin/python (the cross-compiled target binary) makes
+            # FindPython try to exec a non-host binary; it fails and drops the
+            # Interpreter + Development.Module + Development.Embed components.
+            "CROSS_VENV_PYTHON": str(
+                self.cross_venv.venv_path
+                / "cross"
+                / "bin"
+                / f"python{self.cross_venv.sysconfig_data['py_version_short']}"
+            ),
         }
         env.update(kwargs)
 


### PR DESCRIPTION
Adds a `pyzmq` 27.1.0 recipe (requested by https://github.com/flet-dev/flet/discussions/4957), plus one general, reusable forge change (`CROSS_VENV_PYTHON`) that any CMake + FindPython cross-compiled recipe can use.

pyzmq is a `scikit-build-core` + CMake + Cython package that **bundles and builds its own libzmq (C++) and libsodium (autotools, for CURVE)**, so it exercises the full native-toolchain path on both platforms.

## Forge change: `CROSS_VENV_PYTHON` (additive)

New `build.script_env` template variable: the **host-runnable crossenv interpreter** (`<venv>/cross/bin/pythonX.Y`) — a wrapper that runs the build-machine Python but reports the *target* sysconfig.

Why it's needed: CMake's `find_package(Python COMPONENTS Interpreter …)` needs a runnable interpreter. Pointing `-DPython_EXECUTABLE` at `{prefix}/bin/python` (the cross-compiled **target ELF/binary**, not host-runnable) makes FindPython try to exec a foreign binary; it fails and silently drops **all** components:

    Could NOT find Python (missing: Interpreter Development.Module Development.Embed)

This bit pyzmq on Python 3.12/3.13 across every Android arch (3.14 only passed by accidentally falling back to the cross python on `PATH`).

This var is **purely additive** — it has no effect on recipes that don't reference it.

## Recipe: cross-compile fixes

| Issue | Fix |
|---|---|
| scikit-build-core build deps | `requirements.build: [cmake, ninja]` |
| macOS `-arch`/`-isysroot` leaking into the NDK clang | `-DCMAKE_TOOLCHAIN_FILE=…/android.toolchain.cmake`, `-DANDROID_STL=c++_shared` |
| FindPython drops all components when cross-compiling | `-DPython_EXECUTABLE={CROSS_VENV_PYTHON}` |
| vendored libzmq not built (`-lzmq` not found) | `-DZMQ_PREFIX=bundled` |
| bundled libsodium `./configure` can't cross (`cannot run C compiled programs`) | `CIBW_HOST_TRIPLET` — `{HOST_TRIPLET}` (Android), `{{ arch }}-apple-ios` (iOS) |
| libzmq is C++ (Android runtime) | `flet-libcpp-shared` host dep |
| `ninja` pip package crashes importing on the iOS crossenv python (`sysconfig.get_preferred_scheme("user")` → `posix_user` invalid on iOS) | `CMAKE_GENERATOR=Unix Makefiles` (iOS only; Android keeps Ninja) |

iOS triple note: libsodium 1.0.20's `config.sub` accepts `arm64-apple-ios`/`x86_64-apple-ios` but **rejects** the `-simulator`-suffixed forms; `*-apple-ios` is always `!=` the macOS `*-apple-darwin` build triple, so cross is guaranteed. The actual simulator/device codegen comes from forge's iOS CC/`-isysroot`, not the triple.

## Validation

- **CI — full matrix green:** Android + iOS × Python 3.12 / 3.13 / 3.14, all arches.
- **On-device pass:** Android arm64 / Python 3.12 (real phone target) — `import zmq` works and a Context/PAIR/`inproc://` send-recv round-trips through the bundled libzmq + libsodium `.so`.

## Files

- `recipes/pyzmq/meta.yaml` (new)
- `recipes/pyzmq/tests/test_pyzmq.py` (new) — version asserts + an `inproc://` PAIR send/recv (no network, emulator/simulator-safe)
- `src/forge/build.py` — adds the `CROSS_VENV_PYTHON` script_env var