### PR TITLE
Consume `python-build` via pinned date-keyed release + manifest.json

### DIFF
--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -33,11 +33,11 @@ on:
           APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
         type: string
-        default: "3.12.13"
+        default: "3.12"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
-          python-build support tree, instead of the v<version> release tarball:
+          python-build support tree, instead of the pinned date-keyed release tarball:
         required: false
         type: string
         default: ""
@@ -53,10 +53,10 @@ on:
         required: true
         type: choice
         options:
-          - 3.12.13
-          - 3.13.13
-          - 3.14.5
-        default: 3.12.13
+          - "3.12"
+          - "3.13"
+          - "3.14"
+        default: "3.12"
       archs:
         description: |
           Architectures (comma-separated):
@@ -79,11 +79,11 @@ on:
           Versions in `python_versions` that aren't in this list still build wheels but skip the
           APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
-        default: "3.12.13"
+        default: "3.12"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
-          python-build support tree, instead of the v<version> release tarball:
+          python-build support tree, instead of the pinned date-keyed release tarball:
         required: false
         default: ""
 
@@ -111,7 +111,7 @@ jobs:
           ARCHS="${{ inputs.archs }}"
           PACKAGES="${{ inputs.packages }}"
           py="${{ inputs.python_version }}"
-          py_short="${py%.*}"   # 3.12.13 -> 3.12
+          py_short="$(echo "$py" | cut -d. -f1-2)"   # 3.12 or 3.12.13 -> 3.12
 
           matrix='{"include":['
           first=true
@@ -256,7 +256,7 @@ jobs:
           if [[ "$MOBILE_TEST_PYTHONS" != "ALL" ]]; then
             allowed=""
             for v in $(echo "$MOBILE_TEST_PYTHONS" | tr ',' ' '); do
-              allowed="${allowed:+$allowed }${v%.*}"
+              allowed="${allowed:+$allowed }$(echo "$v" | cut -d. -f1-2)"
             done
             if [[ ! " $allowed " == *" $PYTHON_SHORT "* ]]; then
               echo "::notice::Skipping mobile test — py${PYTHON_SHORT} not in mobile_test_pythons=${MOBILE_TEST_PYTHONS}"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -25,18 +25,18 @@ on:
         description: |
           Python versions to fan the matrix across (comma-separated):
         required: false
-        default: "3.12.13,3.13.13,3.14.5"
+        default: "3.12,3.13,3.14"
       mobile_test_pythons:
         description: |
           Python versions (comma-separated) whose recipe mobile tests should actually run.
           Versions in `python_versions` that aren't in this list still build wheels but skip the
           APK/iOS-simulator test stage. Use "ALL" to run tests for every entry in `python_versions`:
         required: false
-        default: "3.12.13"
+        default: "3.12"
       python_build_run_id:
         description: |
           flet-dev/python-build Actions run-id whose artifacts to use as the
-          python-build support tree, instead of the v<version> release tarball:
+          python-build support tree, instead of the pinned date-keyed release tarball:
         required: false
         default: ""
 
@@ -58,11 +58,11 @@ on:
       python_versions:
         type: string
         required: false
-        default: "3.12.13,3.13.13,3.14.5"
+        default: "3.12,3.13,3.14"
       mobile_test_pythons:
         type: string
         required: false
-        default: "3.12.13"
+        default: "3.12"
       python_build_run_id:
         type: string
         required: false
@@ -77,7 +77,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DEFAULT_PYTHONS: "3.12.13,3.13.13,3.14.5"
+  DEFAULT_PYTHONS: "3.12,3.13,3.14"
   # Used as the fallback recipe set when `packages` input is empty
   # (workflow_dispatch/workflow_call) or when no `recipes/**` paths
   # changed in the triggering event (push/pull_request).
@@ -165,7 +165,7 @@ jobs:
       archs: ${{ inputs.archs || 'android,iOS' }}
       packages: ${{ needs.detect.outputs.packages }}
       prebuild_recipes: ${{ inputs.prebuild_recipes || '' }}
-      mobile_test_pythons: ${{ inputs.mobile_test_pythons || '3.12.13' }}
+      mobile_test_pythons: ${{ inputs.mobile_test_pythons || '3.12' }}
       python_build_run_id: ${{ inputs.python_build_run_id || '' }}
     secrets:
       GEMFURY_TOKEN: ${{ secrets.GEMFURY_TOKEN }}

--- a/setup.sh
+++ b/setup.sh
@@ -61,7 +61,10 @@ resolve_full_version() {
     elif command -v python3 >/dev/null 2>&1; then
         full="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("pythons",{}).get(sys.argv[2],{}).get("full_version",""))' "$mf" "$minor" 2>/dev/null)"
     else
-        full="$(sed -n "/\"$minor\"[[:space:]]*:/,/}/p" "$mf" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9]*' | head -1)"
+        # Match the minor literally in the sed range: a bare `.` is a regex
+        # wildcard, so escape each dot to `[.]` (e.g. 3.13 -> 3[.]13).
+        local minor_re="${minor//./[.]}"
+        full="$(sed -n "/\"$minor_re\"[[:space:]]*:/,/}/p" "$mf" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9]*' | head -1)"
     fi
 
     if [ -z "$full" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -34,10 +34,6 @@ if ! command -v uv &> /dev/null; then
 fi
 
 # Pinned flet-dev/python-build release to consume (date-keyed YYYYMMDD, PBS-style).
-# Its manifest.json maps each X.Y -> the full X.Y.Z and names the support tarballs,
-# so we fetch one consistent runtime set by date instead of per-version v<X.Y> tags
-# (which are now frozen upstream). Bump this to adopt a newer CPython set; override
-# with the PYTHON_BUILD_RELEASE env var to test an unpublished date.
 PYTHON_BUILD_RELEASE="${PYTHON_BUILD_RELEASE:-20260614}"
 
 # Resolve a full X.Y.Z from a bare X.Y minor using the pinned release's

--- a/setup.sh
+++ b/setup.sh
@@ -3,9 +3,12 @@ usage() {
     echo
     echo "    source $1 <python version>"
     echo
+    echo "<python version> may be a minor (3.13) or full (3.13.14) version;"
+    echo "a minor is resolved to the patch from the pinned python-build release."
     echo "for example:"
     echo
     echo "    source $1 3.13"
+    echo "    source $1 3.13.14"
     echo
 }
 
@@ -30,16 +33,70 @@ if ! command -v uv &> /dev/null; then
     return
 fi
 
-PYTHON_VERSION=$1
-PYTHON_VER="${PYTHON_VERSION%.*}"
+# Pinned flet-dev/python-build release to consume (date-keyed YYYYMMDD, PBS-style).
+# Its manifest.json maps each X.Y -> the full X.Y.Z and names the support tarballs,
+# so we fetch one consistent runtime set by date instead of per-version v<X.Y> tags
+# (which are now frozen upstream). Bump this to adopt a newer CPython set; override
+# with the PYTHON_BUILD_RELEASE env var to test an unpublished date.
+PYTHON_BUILD_RELEASE="${PYTHON_BUILD_RELEASE:-20260614}"
+
+# Resolve a full X.Y.Z from a bare X.Y minor using the pinned release's
+# manifest.json (downloaded + cached under downloads/). Echoes the full version;
+# returns non-zero (with a message on stderr) if the fetch or lookup fails.
+resolve_full_version() {
+    local minor="$1"
+    local mf="downloads/python-build-manifest-${PYTHON_BUILD_RELEASE}.json"
+    local murl="https://github.com/flet-dev/python-build/releases/download/${PYTHON_BUILD_RELEASE}/manifest.json"
+
+    mkdir -p downloads
+    if [ ! -f "$mf" ]; then
+        if ! curl -fsSL -o "$mf" "$murl"; then
+            echo "Failed to fetch python-build manifest ($murl)." >&2
+            rm -f "$mf"
+            return 1
+        fi
+    fi
+
+    # Prefer jq, then python3; fall back to a scoped sed/grep over the (tiny,
+    # stable-shape) manifest so this works on a bare machine with neither.
+    local full=""
+    if command -v jq >/dev/null 2>&1; then
+        full="$(jq -r --arg m "$minor" '.pythons[$m].full_version // empty' "$mf" 2>/dev/null)"
+    elif command -v python3 >/dev/null 2>&1; then
+        full="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("pythons",{}).get(sys.argv[2],{}).get("full_version",""))' "$mf" "$minor" 2>/dev/null)"
+    else
+        full="$(sed -n "/\"$minor\"[[:space:]]*:/,/}/p" "$mf" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9]*' | head -1)"
+    fi
+
+    if [ -z "$full" ]; then
+        echo "python-build release ${PYTHON_BUILD_RELEASE} has no Python ${minor} in its manifest." >&2
+        return 1
+    fi
+    echo "$full"
+}
+
+# Accept either a full X.Y.Z or a bare X.Y minor as $1. Derive the X.Y minor either
+# way (cut handles both forms); when only the minor is given, resolve the patch from
+# the pinned release's manifest. A full version is taken as-is (works offline and for
+# the PYTHON_BUILD_RUN_ID path, which may build versions other than the pinned set).
+PYTHON_INPUT="$1"
+PYTHON_VER="$(echo "$PYTHON_INPUT" | cut -d. -f1-2)"
 python_version_minor="${PYTHON_VER#*.}"
+
+if echo "$PYTHON_INPUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]'; then
+    PYTHON_VERSION="$PYTHON_INPUT"
+else
+    echo "Resolving Python $PYTHON_VER from python-build release $PYTHON_BUILD_RELEASE..."
+    PYTHON_VERSION="$(resolve_full_version "$PYTHON_VER")" || return
+fi
 
 echo "Python version: $PYTHON_VERSION"
 echo "Python short version: $PYTHON_VER"
+echo "python-build release: $PYTHON_BUILD_RELEASE"
 
 # Download (and cache) a mobile-forge Python support package, extracting it
-# into $2. Source is either the canonical v<version> release on
-# flet-dev/python-build, or a specific Actions run's artifacts when
+# into $2. Source is either the pinned date-keyed ($PYTHON_BUILD_RELEASE) release
+# on flet-dev/python-build, or a specific Actions run's artifacts when
 # $PYTHON_BUILD_RUN_ID is set (used in CI to validate unreleased
 # python-build branches against the recipe matrix). Tarballs are cached
 # under downloads/ (gitignored) and reused on subsequent runs.
@@ -49,7 +106,7 @@ echo "Python short version: $PYTHON_VER"
 #                          (requires `gh` installed and a GITHUB_TOKEN / login)
 download_support() {
     local plat="$1" dest="$2"
-    local tarball="python-${plat}-mobile-forge-${PYTHON_VER}.tar.gz"
+    local tarball="python-${plat}-mobile-forge-${PYTHON_VERSION}.tar.gz"
 
     if [ -d "$dest/support" ]; then
         return 0
@@ -62,7 +119,7 @@ download_support() {
             # (it bundles iOS + macOS together). The android lane has a 1:1 artifact name.
             local artifact_plat="$plat"
             [ "$plat" = "ios" ] && artifact_plat="darwin"
-            local artifact_name="python-${artifact_plat}-${PYTHON_VER}"
+            local artifact_name="python-${artifact_plat}-${PYTHON_VERSION}"
 
             echo "Fetching ${tarball} from python-build run ${PYTHON_BUILD_RUN_ID} (artifact: ${artifact_name})..."
             local stage
@@ -78,7 +135,7 @@ download_support() {
             mv "$stage/${tarball}" "downloads/${tarball}"
             rm -rf "$stage"
         else
-            local url="https://github.com/flet-dev/python-build/releases/download/v${PYTHON_VER}/${tarball}"
+            local url="https://github.com/flet-dev/python-build/releases/download/${PYTHON_BUILD_RELEASE}/${tarball}"
             echo "Downloading ${tarball}..."
             if ! curl -fL -o "downloads/${tarball}" "$url"; then
                 echo "Failed to download ${url}"
@@ -195,12 +252,12 @@ if [ -z "$explicit" ]; then
     for p in $(echo "$platforms" | tr ',' ' '); do
         case "$(echo "$p" | tr '[:upper:]' '[:lower:]')" in
             ios)
-                dest="$(pwd)/downloads/support/python-ios-mobile-forge-${PYTHON_VER}"
+                dest="$(pwd)/downloads/support/python-ios-mobile-forge-${PYTHON_VERSION}"
                 download_support ios "$dest" || return
                 export MOBILE_FORGE_IOS_SUPPORT_PATH="$(resolve_support_root "$dest")"
                 ;;
             android)
-                dest="$(pwd)/downloads/support/python-android-mobile-forge-${PYTHON_VER}"
+                dest="$(pwd)/downloads/support/python-android-mobile-forge-${PYTHON_VERSION}"
                 download_support android "$dest" || return
                 export MOBILE_FORGE_ANDROID_SUPPORT_PATH="$(resolve_support_root "$dest")"
                 ;;
@@ -321,4 +378,4 @@ echo "   forge iOS --all-versions lru-dict"
 echo
 
 # The script is sourced; don't leave helper functions in the user's shell.
-unset -f download_support resolve_support_root relocate_pkgconfig_prefix
+unset -f download_support resolve_support_root relocate_pkgconfig_prefix resolve_full_version


### PR DESCRIPTION
[flet-dev/python-build](https://github.com/flet-dev/python-build) switched its release model (PRs #14/#15): from per-version `v<X.Y>` tags to **PBS-style date-keyed releases** (`YYYYMMDD`), each carrying a **`manifest.json`** that is the single source of truth — it maps each `X.Y` → `full_version` and the per-platform support tarballs are now named by the **full** version. The old `v<X.Y>` tags still exist but are **frozen**, so mobile-forge was silently pinned to stale runtimes (missing the 3.13.14 / 3.14.6 bumps and the recent Android/iOS build fixes).

This updates how mobile-forge consumes python-build to follow the new standard: pin a release date, resolve the patch from that release's manifest, and download the full-version-named tarballs.

## `setup.sh`

- **Pin** `PYTHON_BUILD_RELEASE` (date-keyed, env-overridable; default `20260614`)
  — the single anchor for the runtime set, replacing the per-version `v<X.Y>` tag.
- **Accepts a minor *or* full version:** `source ./setup.sh 3.13` or `source ./setup.sh 3.13.14`.
  - The `X.Y` minor is derived with `cut -d. -f1-2`
  - A minor is resolved to its patch from the pinned release's `manifest.json` (new `resolve_full_version` helper: jq → python3 → sed fallback, cached under `downloads/`).
  - A full version is taken as-is (works offline, and for the `PYTHON_BUILD_RUN_ID` path, which may build versions outside the pinned set).
- **Downloads** from the date tag with full-version tarball / artifact names; the cache + extract dirs are keyed by full version so bumping the pin re-fetches cleanly.

## CI (`build-wheels.yml` / `build-wheels-version.yml`)

- The matrix now passes **minors** (`3.12,3.13,3.14`; `DEFAULT_PYTHONS`) so setup.sh resolves each to the pinned release's patch — single source of truth. Previously hardcoded `3.12.13,3.13.13,3.14.5`, of which `3.13.13` and `3.14.5` don't exist in release `20260614`.
- `py_short` and the `mobile_test_pythons` matching are made minor-safe (`cut -f1-2` instead of `%.*`), and the dispatch `python_version` choices are now `3.12/3.13/3.14`.

## Files

- `setup.sh` — pin + dual-form arg + manifest resolution + new download contract
- `.github/workflows/build-wheels.yml` — pass minors
- `.github/workflows/build-wheels-version.yml` — pass minors + minor-safe derivations