### PR TITLE
recipe: python-magic 0.4.27 (+ flet-libmagic 5.46)

### DIFF
--- a/recipes/flet-libmagic/build.sh
+++ b/recipes/flet-libmagic/build.sh
@@ -19,7 +19,12 @@ common_args="\
 # native `file` first (out-of-tree) and point the cross build at it via
 # FILE_COMPILE so the DB is compiled by a host binary of the SAME version.
 mkdir -p _hostbuild
-( cd _hostbuild && ../configure --silent $common_args --disable-shared >/dev/null && make -j "$CPU_COUNT" >/dev/null )
+# Force the NATIVE build toolchain here: forge exports the cross CC/CFLAGS/etc.
+# for the target, but this `file` must run on the build machine to compile the DB.
+( cd _hostbuild && \
+    CC=cc CXX=c++ CPP="cc -E" CFLAGS= CXXFLAGS= CPPFLAGS= LDFLAGS= AR=ar RANLIB=ranlib STRIP=strip \
+    ../configure --silent $common_args --disable-shared >/dev/null && \
+    make -j "$CPU_COUNT" >/dev/null )
 HOST_FILE="$PWD/_hostbuild/src/file"
 
 if [ "$CROSS_VENV_SDK" = "android" ]; then
@@ -68,7 +73,8 @@ else
     cd - >/dev/null
 fi
 
-# Keep opt/lib/libmagic.so + opt/share/misc/magic.mgc; drop everything else.
+# Keep opt/lib/libmagic.so + opt/share/misc/magic.mgc; drop everything else
+# (the host `file` binary, headers, man pages, pkgconfig, libtool archives).
 shopt -s nullglob
-rm -rf "$PREFIX/bin" "$PREFIX/include"
+rm -rf "$PREFIX/bin" "$PREFIX/include" "$PREFIX/share/man"
 rm -rf "$PREFIX/lib/pkgconfig" "$PREFIX"/lib/*.la

--- a/recipes/flet-libmagic/build.sh
+++ b/recipes/flet-libmagic/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# flet-libmagic: libmagic (the `file` library) as a SHARED library (Pattern H)
+# for python-magic's ctypes loader. Ships:
+#   - opt/lib/libmagic.so          (the lib python-magic dlopens)
+#   - opt/share/misc/magic.mgc     (the compiled magic database libmagic loads)
+# serious-python surfaces the .so into Android jniLibs / an iOS framework; the
+# magic.mgc data file rides along in the wheel for the loader to point at.
+set -eu
+
+NAME=magic
+
+common_args="\
+    --disable-dependency-tracking \
+    --disable-libseccomp \
+    --disable-bzlib --disable-xzlib --disable-zlib --disable-zstdlib --disable-lzlib"
+
+# The magic database (magic.mgc) is compiled by the `file` tool at build time.
+# Cross-compiling, the target `file` can't run on the build host, so build a
+# native `file` first (out-of-tree) and point the cross build at it via
+# FILE_COMPILE so the DB is compiled by a host binary of the SAME version.
+mkdir -p _hostbuild
+( cd _hostbuild && ../configure --silent $common_args --disable-shared >/dev/null && make -j "$CPU_COUNT" >/dev/null )
+HOST_FILE="$PWD/_hostbuild/src/file"
+
+if [ "$CROSS_VENV_SDK" = "android" ]; then
+    ./configure \
+        --host=$HOST_TRIPLET \
+        --prefix=$PREFIX \
+        --enable-shared --disable-static \
+        $common_args
+    make -j "$CPU_COUNT" FILE_COMPILE="$HOST_FILE"
+    make install FILE_COMPILE="$HOST_FILE"
+
+    # Collapse versioned .so + symlinks to a single unversioned libmagic.so
+    # (Android extracts only files literally matching lib*.so; python-magic
+    # dlopens "libmagic.so" by name).
+    cd "$PREFIX/lib"
+    real=$(readlink -f "lib$NAME.so")
+    tmp=$(mktemp); cp "$real" "$tmp"
+    rm -f "lib$NAME.so" "lib$NAME.so".*
+    mv "$tmp" "lib$NAME.so"; chmod 755 "lib$NAME.so"
+    cd - >/dev/null
+else
+    # iOS: libtool can't emit a versioned darwin dylib under cross-compile, so
+    # build static then hand-link the shared lib. config.sub doesn't know Apple
+    # mobile triplets — feed it an equivalent Darwin triplet (CC/CFLAGS do the
+    # real targeting).
+    case $HOST_TRIPLET in
+        arm64-apple-ios)            host=arm-apple-darwin23 ;;
+        arm64-apple-ios-simulator)  host=aarch64-apple-darwin23 ;;
+        x86_64-apple-ios-simulator) host=x86_64-apple-darwin23 ;;
+        *) echo "Unknown iOS host triplet: $HOST_TRIPLET"; exit 1 ;;
+    esac
+    ./configure \
+        --host=$host \
+        --prefix=$PREFIX \
+        --enable-static --disable-shared \
+        $common_args
+    make -j "$CPU_COUNT" FILE_COMPILE="$HOST_FILE"
+    make install FILE_COMPILE="$HOST_FILE"
+
+    cd "$PREFIX/lib"
+    $CC $CFLAGS -shared \
+        -Wl,-all_load "lib$NAME.a" \
+        -install_name "@rpath/lib$NAME.so" \
+        -o "lib$NAME.so"
+    rm -f "lib$NAME.a"
+    cd - >/dev/null
+fi
+
+# Keep opt/lib/libmagic.so + opt/share/misc/magic.mgc; drop everything else.
+shopt -s nullglob
+rm -rf "$PREFIX/bin" "$PREFIX/include"
+rm -rf "$PREFIX/lib/pkgconfig" "$PREFIX"/lib/*.la

--- a/recipes/flet-libmagic/build.sh
+++ b/recipes/flet-libmagic/build.sh
@@ -56,7 +56,11 @@ else
         x86_64-apple-ios-simulator) host=x86_64-apple-darwin23 ;;
         *) echo "Unknown iOS host triplet: $HOST_TRIPLET"; exit 1 ;;
     esac
-    ./configure \
+    # iOS's simulator SDK exports pipe2 as a linkable symbol (so configure's
+    # cross AC_CHECK_FUNC sets HAVE_PIPE2) but doesn't declare it for the
+    # deployment target -> implicit-declaration error in funcs.c. Force it off
+    # so file uses its pipe()+fcntl fallback.
+    ac_cv_func_pipe2=no ./configure \
         --host=$host \
         --prefix=$PREFIX \
         --enable-static --disable-shared \

--- a/recipes/flet-libmagic/meta.yaml
+++ b/recipes/flet-libmagic/meta.yaml
@@ -1,0 +1,13 @@
+{% set version = "5.46" %}
+
+package:
+  name: flet-libmagic
+  version: '{{ version }}'
+
+source:
+  # The `file` project ships a release tarball with a pre-generated ./configure
+  # (autotools), so no autoreconf is needed (unlike flet-libzbar).
+  url: https://astron.com/pub/file/file-{{ version }}.tar.gz
+
+build:
+  number: 0

--- a/recipes/flet-libmagic/meta.yaml
+++ b/recipes/flet-libmagic/meta.yaml
@@ -4,10 +4,10 @@ package:
   name: flet-libmagic
   version: '{{ version }}'
 
+build:
+  number: 1
+
 source:
   # The `file` project ships a release tarball with a pre-generated ./configure
   # (autotools), so no autoreconf is needed (unlike flet-libzbar).
   url: https://astron.com/pub/file/file-{{ version }}.tar.gz
-
-build:
-  number: 1

--- a/recipes/flet-libmagic/meta.yaml
+++ b/recipes/flet-libmagic/meta.yaml
@@ -10,4 +10,4 @@ source:
   url: https://astron.com/pub/file/file-{{ version }}.tar.gz
 
 build:
-  number: 0
+  number: 1

--- a/recipes/python-magic/meta.yaml
+++ b/recipes/python-magic/meta.yaml
@@ -1,0 +1,19 @@
+{% set version = "0.4.27" %}
+
+package:
+  name: python-magic
+  version: '{{ version }}'
+
+build:
+  number: 0
+
+requirements:
+  host:
+    # python-magic is a pure-Python ctypes wrapper that dlopens libmagic at
+    # runtime (loader + magic-db default patched by mobile.patch). Ship libmagic
+    # and its magic.mgc database on both platforms; fix_wheel turns this into a
+    # Requires-Dist so pip pulls it.
+    - flet-libmagic 5.46
+
+patches:
+  - mobile.patch

--- a/recipes/python-magic/meta.yaml
+++ b/recipes/python-magic/meta.yaml
@@ -1,11 +1,9 @@
-{% set version = "0.4.27" %}
-
 package:
   name: python-magic
-  version: '{{ version }}'
+  version: 0.4.27
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipes/python-magic/patches/mobile.patch
+++ b/recipes/python-magic/patches/mobile.patch
@@ -1,0 +1,43 @@
+diff --git a/magic/loader.py b/magic/loader.py
+index 931f161..60479a0 100644
+--- a/magic/loader.py
++++ b/magic/loader.py
+@@ -8,6 +8,16 @@ def _lib_candidates():
+ 
+   yield find_library('magic')
+ 
++  # mobile-forge: flet-libmagic ships libmagic under <site-packages>/opt/lib and
++  # serious-python surfaces it (Android jniLibs / iOS framework). find_library()
++  # returns None on iOS/Android, so also try the bundled lib + native-dir names.
++  _optlib = os.path.join(
++    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'opt', 'lib')
++  yield os.path.join(_optlib, 'libmagic.fwork')   # iOS embedded framework
++  yield os.path.join(_optlib, 'libmagic.so')      # generic shipped path
++  yield 'libmagic.so'                              # Android jniLibs
++  yield 'libmagic.dylib'                           # desktop fallback
++
+   if sys.platform == 'darwin':
+ 
+     paths = [
+diff --git a/magic/__init__.py b/magic/__init__.py
+index bab7c7b..e389603 100644
+--- a/magic/__init__.py
++++ b/magic/__init__.py
+@@ -70,6 +70,17 @@ class Magic:
+         self.cookie = magic_open(self.flags)
+         self.lock = threading.Lock()
+ 
++        # mobile-forge: on iOS/Android there is no system magic database, so
++        # default to the magic.mgc shipped by the flet-libmagic wheel at
++        # <site-packages>/opt/share/misc/magic.mgc when no explicit db is given.
++        if magic_file is None:
++            import os
++            _bundled_db = os.path.join(
++                os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
++                'opt', 'share', 'misc', 'magic.mgc')
++            if os.path.exists(_bundled_db):
++                magic_file = _bundled_db
++
+         magic_load(self.cookie, magic_file)
+ 
+         # MAGIC_EXTENSION was added in 523 or 524, so bail if

--- a/recipes/python-magic/tests/test_python_magic.py
+++ b/recipes/python-magic/tests/test_python_magic.py
@@ -1,0 +1,24 @@
+def test_libmagic_loads():
+    """Importing magic runs the patched ctypes loader for the bundled libmagic
+    (raises ImportError on-device if libmagic can't be found/loaded)."""
+    import magic
+
+    assert magic.libmagic is not None
+
+
+def test_detect_from_buffer():
+    """from_buffer() identifies a type through libmagic + the bundled magic.mgc
+    database — proving the .so AND the magic DB both load and a real detection
+    runs through the C library (in-memory, so emulator/sim-safe).
+
+    Uses a minimal but VALID PNG (signature + a real IHDR chunk); the bare
+    8-byte signature alone is reported as generic "data"."""
+    import magic
+
+    png = (
+        b"\x89PNG\r\n\x1a\n"
+        b"\x00\x00\x00\rIHDR"
+        b"\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06\x00\x00\x00\x1f\x15\xc4\x89"
+    )
+    assert "PNG" in magic.from_buffer(png)
+    assert magic.from_buffer(png, mime=True) == "image/png"


### PR DESCRIPTION
Adds `python-magic` 0.4.27 (libmagic-based file-type / MIME detection) and its native dependency `flet-libmagic` 5.46 (the `file` project's libmagic). (requested by https://github.com/flet-dev/flet/discussions/4674)

This is a **Pattern H** recipe (pure-Python `ctypes` wrapper + a shared native lib loaded at runtime), the same shape as pyzbar→libzbar. **No forge or CI changes are needed** — libmagic's release ships a pre-generated `./configure` (no autoreconf/gettext), python-magic publishes a PyPI sdist, and flet-libmagic is built for both platforms.

## flet-libmagic 5.46

libmagic from the `file` project (built from the release tarball at `astron.com/pub/file/`). Shared library for ctypes (`opt/lib/libmagic.so`) plus its compiled magic database (`opt/share/misc/magic.mgc`). Compression/seccomp disabled (`--disable-bzlib/xzlib/zlib/zstdlib/lzlib --disable-libseccomp`) to avoid extra deps. Android builds shared + collapses the versioned `.so`; iOS builds static then hand-links the shared dylib (Darwin host triplet, since config.sub doesn't know Apple-mobile triplets).

Two cross-compile wrinkles:
- **magic.mgc** is compiled by the `file` tool, which can't run cross-compiled. build.sh builds a **native `file` first** (forcing the native toolchain, since forge exports the cross CC/CFLAGS) and passes `FILE_COMPILE` to the cross build so the DB is compiled by a host binary of the same version.
- **iOS `pipe2`** — the simulator SDK exports `pipe2` as a linkable symbol so configure's cross `AC_CHECK_FUNC` set `HAVE_PIPE2`, but the deployment-target headers don't declare it (implicit-declaration error in `funcs.c`). Forced `ac_cv_func_pipe2=no` on iOS so file uses its `pipe()`+`fcntl` fallback.

## python-magic 0.4.27

Pure-Python `ctypes` wrapper; built from the PyPI sdist. `patches/mobile.patch`:
- **loader** (`magic/loader.py`) — `ctypes.util.find_library('magic')` returns `None` on iOS/Android, so `_lib_candidates` also yields the bundled libmagic (`opt/lib/libmagic.{fwork,so}` + bare `libmagic.so`/`.dylib`).
- **magic DB** (`magic/__init__.py`) — there's no system magic database on mobile, so `Magic.__init__` defaults `magic_file` to the bundled `opt/share/misc/magic.mgc` when none is given.
- `requirements.host: flet-libmagic 5.46` → `Requires-Dist` via `fix_wheel`.

## Validation

- **CI — full matrix green:** android + iOS × Python 3.12 / 3.13 / 3.14.
- **On-device PASS on CI:** android emulator (x86_64) **and** iOS simulator (3.12) — `import magic` loads libmagic, and a PNG is detected through libmagic + the bundled `magic.mgc`. Also verified android arm64 locally.

## Files

- `recipes/flet-libmagic/{meta.yaml,build.sh}` (new)
- `recipes/python-magic/{meta.yaml,patches/mobile.patch,tests/test_python_magic.py}` (new)