### PR TITLE
fix: default primp mobile requests to `GaiResolver`

### DIFF
--- a/recipes/primp/meta.yaml
+++ b/recipes/primp/meta.yaml
@@ -3,4 +3,7 @@ package:
   version: 1.3.1
 
 build:
-  number: 10
+  number: 11
+
+patches:
+  - mobile.patch

--- a/recipes/primp/patches/mobile.patch
+++ b/recipes/primp/patches/mobile.patch
@@ -1,0 +1,27 @@
+On Android, primp's Python extension enables the `hickory-dns` feature, and
+primp-reqwest follows reqwest's default of using Hickory whenever that feature
+is compiled in. Hickory 0.26 reads Android DNS servers through `ndk-context`;
+that crate expects a Rust/NDK app runtime to call
+`initialize_android_context()` before use.
+
+Flet loads primp as a Python extension inside serious_python, so that Rust
+global is not initialized. The first request then aborts the process from the
+DartWorker thread with:
+
+    android context was not initialized
+
+Use the getaddrinfo-backed resolver by default on Android. Custom DNS resolver
+options exposed by primp remain available; this only changes the automatic
+default chosen for ordinary `primp.Client().get(...)` calls.
+
+--- a/crates/primp-reqwest/src/async_impl/client.rs
++++ b/crates/primp-reqwest/src/async_impl/client.rs
+@@ -406,7 +406,7 @@ impl ClientBuilder {
+                 ))]
+                 interface: None,
+                 nodelay: true,
+-                hickory_dns: cfg!(feature = "hickory-dns"),
++                hickory_dns: cfg!(all(feature = "hickory-dns", not(target_os = "android"))),
+                 #[cfg(feature = "cookies")]
+                 cookie_store: None,
+                 https_only: false,

--- a/recipes/primp/patches/mobile.patch
+++ b/recipes/primp/patches/mobile.patch
@@ -10,18 +10,30 @@ DartWorker thread with:
 
     android context was not initialized
 
-Use the getaddrinfo-backed resolver by default on Android. Custom DNS resolver
-options exposed by primp remain available; this only changes the automatic
-default chosen for ordinary `primp.Client().get(...)` calls.
+Use the getaddrinfo-backed resolver by default for the Python binding on
+mobile when the caller has not supplied an explicit resolver. Custom DNS
+resolver options exposed by primp remain available; this only changes the
+automatic default chosen for ordinary `primp.Client().get(...)` calls.
 
---- a/crates/primp-reqwest/src/async_impl/client.rs
-+++ b/crates/primp-reqwest/src/async_impl/client.rs
-@@ -406,7 +406,7 @@ impl ClientBuilder {
-                 ))]
-                 interface: None,
-                 nodelay: true,
--                hickory_dns: cfg!(feature = "hickory-dns"),
-+                hickory_dns: cfg!(all(feature = "hickory-dns", not(target_os = "android"))),
-                 #[cfg(feature = "cookies")]
-                 cookie_store: None,
-                 https_only: false,
+--- a/crates/primp-python/src/client_builder.rs
++++ b/crates/primp-python/src/client_builder.rs
+@@ -226,6 +226,19 @@ pub fn configure_client_builder(
+     // DNS resolver (fallback chain)
+     if !dns_resolvers.is_empty() {
+         builder = builder.dns_resolver(dns_resolvers);
++    } else {
++        // flet-dev/flet#6603: hickory-dns is compiled in, which makes Hickory
++        // the default resolver. On Android, Hickory's system DNS path calls
++        // ndk_context::android_context(), but Flet/serious_python does not
++        // initialize that Rust global. With panic=abort, the first request
++        // SIGABRTs before Python can raise. getaddrinfo resolves through the
++        // platform resolver and needs no Android Context. Explicit DoH/DoT/plain
++        // resolvers still use the user-selected Hickory-backed paths.
++        #[cfg(any(target_os = "android", target_os = "ios"))]
++        {
++            let gai: Arc<dyn Resolve> = Arc::new(::primp::dns::gai::GaiResolver::new());
++            builder = builder.dns_resolver(vec![gai]);
++        }
+     }
+ 
+     Ok((builder, proxy))

--- a/recipes/primp/tests/test_primp.py
+++ b/recipes/primp/tests/test_primp.py
@@ -21,3 +21,24 @@ def test_exception_hierarchy():
     assert issubclass(primp.ConnectError, primp.RequestError)
     assert issubclass(primp.TimeoutError, primp.RequestError)
     assert issubclass(primp.StatusError, primp.PrimpError)
+
+
+def test_https_request_does_not_abort_process():
+    """Exercise the first network request path.
+
+    On Android, primp 1.3.1 previously aborted natively before Python could
+    raise because the default Hickory resolver tried to read Android DNS config
+    through an uninitialized ndk-context.
+    """
+    import primp
+
+    client = primp.Client(timeout=10, connect_timeout=10)
+    try:
+        response = client.get("https://example.com")
+    except primp.RequestError:
+        # Some device/CI environments have restricted outbound networking.
+        # The regression we need to catch is a native abort, not a Python-level
+        # request failure.
+        return
+
+    assert response.status_code < 600

--- a/recipes/primp/tests/test_primp.py
+++ b/recipes/primp/tests/test_primp.py
@@ -24,11 +24,10 @@ def test_exception_hierarchy():
 
 
 def test_https_request_does_not_abort_process():
-    """Exercise the first network request path.
+    """A first HTTPS request should either complete or raise a Python error.
 
-    On Android, primp 1.3.1 previously aborted natively before Python could
-    raise because the default Hickory resolver tried to read Android DNS config
-    through an uninitialized ndk-context.
+    Mobile runtimes must not abort the process while initializing DNS, TLS, or
+    other native request machinery.
     """
     import primp
 
@@ -36,9 +35,11 @@ def test_https_request_does_not_abort_process():
     try:
         response = client.get("https://example.com")
     except primp.RequestError:
+        print("primp HTTPS request result: RequestError")
         # Some device/CI environments have restricted outbound networking.
         # The regression we need to catch is a native abort, not a Python-level
         # request failure.
         return
 
+    print(f"primp HTTPS request result: status={response.status_code}")
     assert response.status_code < 600


### PR DESCRIPTION
Fixes the `primp` mobile recipe so ordinary Android HTTPS requests no longer abort natively on first use.

Resolves https://github.com/flet-dev/flet/issues/6603

## Cause

`primp` is built with the `hickory-dns` feature enabled. In `primp-reqwest`, that makes Hickory the default DNS resolver when the caller does not provide one.

On Android, Hickory’s system DNS configuration path calls into `ndk-context` to access the Android `Context`. Flet loads `primp` as a Python extension through `serious_python`, and that Rust Android context is not initialized there. As a result, the first network request can abort the process with:

```text
android context was not initialized
```

This happens below Python, so the app can crash before a Python exception can be raised or caught.

## Fix

The recipe patch now changes the Python binding’s client builder behavior for mobile builds:

- if the user passes an explicit `dns_resolver`, keep using that resolver
- otherwise, on Android/iOS, install `GaiResolver` as the default resolver

This routes normal hostname resolution through the platform `getaddrinfo` path and avoids Hickory’s Android `ndk-context` system-DNS path. Explicit DoH/DoT/plain resolver support remains available.

The recipe test now performs a real HTTPS request and asserts that the request path either completes or raises a Python-level request error, rather than aborting the process.