### PR TITLE
recipe: oracledb 4.0.1

### DIFF
--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -276,10 +276,13 @@ jobs:
             forge "$FORGE_ARCH" "$package"
           done
 
-          # Drop the support-tree dep wheels produced by make_dep_wheels.py
-          # iOS deps: bzip2, libffi, mpdecimal, openssl, xz
-          # Android deps: bzip2, libffi, openssl, sqlite, xz
-          rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
+      - name: Drop support-tree dep wheels
+        if: always()
+        shell: bash
+        # Drop the CPython support-tree dep wheels produced by make_dep_wheels.py
+        # iOS deps: bzip2, libffi, mpdecimal, openssl, xz
+        # Android deps: bzip2, libffi, openssl, sqlite, xz
+        run: rm -f dist/bzip2-* dist/libffi-* dist/mpdecimal-* dist/openssl-* dist/sqlite-* dist/xz-*
 
       - name: Summarize built wheels
         if: always()

--- a/recipes/oracledb/meta.yaml
+++ b/recipes/oracledb/meta.yaml
@@ -1,0 +1,18 @@
+package:
+  name: oracledb
+  version: 4.0.1
+
+build:
+  number: 1
+
+requirements:
+  # python-oracledb compiles four Cython extensions (base_impl, thin_impl,
+  # thick_impl, arrow_impl) from .pyx via setuptools+Cython. All native deps are
+  # vendored in the sdist (ODPI-C for thick mode, nanoarrow for arrow), so there
+  # is NO external native library to link — no flet-lib* host dep needed.
+  # `cryptography` (a shipped recipe) and `typing_extensions` (pure-Python) are
+  # runtime deps carried in the wheel metadata and resolved at app-build time.
+  # Thick mode dlopens the Oracle Instant Client at runtime only (absent on
+  # mobile); the default THIN mode is pure sockets and needs no client libs.
+  build:
+    - cython

--- a/recipes/oracledb/tests/test_oracledb.py
+++ b/recipes/oracledb/tests/test_oracledb.py
@@ -1,0 +1,29 @@
+def test_import_and_thin_mode():
+    """Loads all four Cython extensions — oracledb/__init__.py does
+    `from . import base_impl, thick_impl, thin_impl` (and arrow) at import, so
+    this proves every .so cross-compiled and loads. thick_impl loads WITHOUT the
+    Oracle Instant Client (ODPI-C dlopens it lazily, only on thick init), and the
+    default THIN mode needs no Oracle client libraries at all."""
+    import oracledb
+
+    assert oracledb.__version__
+    assert oracledb.is_thin_mode() is True
+
+
+def test_thin_connect_errors_cleanly():
+    """No DB server here — prove the thin driver's Cython network/protocol path
+    actually RUNS on-device by connecting to an unreachable listener and getting
+    a clean `oracledb.Error` (DB-API base), not an ImportError or native crash."""
+    import oracledb
+
+    try:
+        oracledb.connect(
+            user="x",
+            password="x",
+            dsn="127.0.0.1:1521/FREEPDB1",
+            tcp_connect_timeout=3,
+        )
+    except oracledb.Error:
+        pass  # expected: nothing is listening, thin driver reports it cleanly
+    else:
+        raise AssertionError("expected a connection error against an unreachable DB")


### PR DESCRIPTION
Adds **python-oracledb 4.0.1** (official Oracle Database driver) for iOS and Android.

Closes flet-dev/flet#3249. Also supersedes the cx_Oracle request (flet-dev/flet#3381), which is infeasible on mobile (it requires the proprietary Oracle Instant Client); oracledb's default **thin mode** needs no Oracle client libraries.

## Recipe shape
Plain **Cython C-extension, no patches, no `flet-lib*` dependency.** python-oracledb compiles four Cython extensions (`base_impl`, `thin_impl`, `thick_impl`, `arrow_impl`), and bundles all its native code in the sdist — ODPI-C (for thick mode) and nanoarrow (for Arrow dataframes) — so there's no external native library to build or link. 

Runtime deps `cryptography` (already on pypi.flet.dev) and `typing_extensions` (pure-Python) come from the wheel metadata and resolve at app-build time.

## Thin vs thick mode
The default **thin mode** is a pure-socket implementation of Oracle Net — no Oracle client libraries required, so it works on mobile. `thick_impl.so` is imported at package load (`oracledb/__init__.py`) and builds/loads fine without the Instant Client (ODPI-C `dlopen`s it lazily, only on `init_oracle_client()`), so thick mode is simply unavailable on mobile while thin mode — the supported path — works.

## Tested
- **Full matrix builds green (zero patches):** Android `arm64-v8a`/`armeabi-v7a`/`x86`/`x86_64` and iOS `arm64` (device) / `arm64` (simulator) / `x86_64` (simulator), Python 3.12.
- **On-device against a LIVE database** (Android arm64 emulator + iOS simulator): `import oracledb` loads all four Cython extensions, `is_thin_mode()` is `True`, `cryptography` loads, and a real thin-mode round-trip — Oracle Net handshake + O5LOGON crypto auth + `SELECT 'hello-from-flet', SYSDATE FROM dual` — succeeds against Oracle Database Free 23ai (server 23.26.2.0.0), returning the expected row on **both** platforms.