### PR TITLE
recipe: duckdb 1.5.4

### DIFF
--- a/recipes/duckdb/meta.yaml
+++ b/recipes/duckdb/meta.yaml
@@ -1,0 +1,49 @@
+package:
+  name: duckdb
+  version: 1.5.4
+
+requirements:
+  build:
+    # duckdb builds via scikit-build-core + CMake (Ninja generator); with forge's
+    # `--no-isolation` these must be in the build venv. scikit-build-core,
+    # pybind11 and setuptools_scm come from the package's own build-system.requires.
+    - cmake
+    - ninja
+# {% if sdk == 'android' %}
+  host:
+    # duckdb's _duckdb.so is C++; on Android it links libc++_shared.so, which the
+    # device runtime doesn't provide unless bundled.
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+build:
+  number: 1
+  script_env:
+# {% if sdk == 'android' %}
+    CMAKE_ARGS: >-
+      -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake
+      -DANDROID_ABI={ANDROID_ABI}
+      -DANDROID_NATIVE_API_LEVEL={ANDROID_API_LEVEL}
+      -DANDROID_STL=c++_shared
+      -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+      -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
+# {% else %}
+    # The `ninja` pip package crashes importing on the iOS crossenv python
+    # (sysconfig.get_preferred_scheme('user') -> 'posix_user' invalid on iOS),
+    # so use the Makefiles generator on iOS; scikit-build-core then never imports
+    # ninja. (Android keeps Ninja, which works there.)
+    CMAKE_GENERATOR: Unix Makefiles
+    CMAKE_ARGS: >-
+      -DCMAKE_SYSTEM_NAME=iOS
+      -DCMAKE_OSX_SYSROOT={{ sdk }}
+      -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
+      -DCMAKE_OSX_ARCHITECTURES={{ arch }}
+      -DCMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/env
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
+# {% endif %}

--- a/recipes/duckdb/tests/test_duckdb.py
+++ b/recipes/duckdb/tests/test_duckdb.py
@@ -1,0 +1,27 @@
+def test_import_version():
+    """Loads the _duckdb pybind11 C++ extension (the canary that the big C++
+    engine cross-compiled and links its C++ runtime)."""
+    import duckdb
+
+    assert duckdb.__version__
+
+
+def test_in_memory_query():
+    """duckdb is an in-process OLAP engine — no server needed. Open an in-memory
+    database and run a CREATE/INSERT/SELECT round-trip through the engine."""
+    import duckdb
+
+    con = duckdb.connect(":memory:")
+    try:
+        assert con.execute("SELECT 42").fetchone() == (42,)
+
+        con.execute("CREATE TABLE t(id INTEGER, name VARCHAR)")
+        con.executemany("INSERT INTO t VALUES (?, ?)", [(1, "apple"), (2, "banana")])
+        rows = con.execute("SELECT id, name FROM t ORDER BY id").fetchall()
+        assert rows == [(1, "apple"), (2, "banana")], rows
+
+        # an aggregate to exercise the analytical engine path
+        total = con.execute("SELECT sum(id) FROM t").fetchone()
+        assert total == (3,), total
+    finally:
+        con.close()


### PR DESCRIPTION
Adds **duckdb** 1.5.4 — the in-process analytical (OLAP) database — for iOS and Android.

Closes flet-dev/flet#3881.

## Recipe shape
scikit-build-core + CMake (C++11), no patches. The `_duckdb` pybind11 extension is the whole engine; duckdb + ICU + all third-party are vendored in the sdist, so there are **no external native dependencies** and no mandatory runtime deps:
- `requirements.build: [cmake, ninja]` (scikit-build-core / pybind11 / setuptools_scm come from the package's own `build-system.requires`).
- **Android:** `flet-libcpp-shared` host dep (the C++ runtime), `ANDROID_STL=c++_shared`, and 16 KB-alignment linker flags; FindPython via `CROSS_VENV_PYTHON`.
- **iOS:** `Unix Makefiles` generator (the `ninja` pip package crashes on the iOS crossenv Python) + `CMAKE_SYSTEM_NAME=iOS`; same `CROSS_VENV_PYTHON` FindPython.

It's a heavy package (the `_duckdb.so` is ~15–18 MB/arch).

## Tested
- Full matrix builds green: Android (arm64-v8a, armeabi-v7a, x86, x86_64) + iOS (arm64 device, arm64 sim, x86_64 sim), Python 3.12 — no patches, 32-bit arches build cleanly.
- On-device (Android arm64 emulator + iOS simulator): `import duckdb` loads the C++ engine and a real in-memory `CREATE`/`INSERT`/`SELECT` + aggregate round-trip returns correct results.