### PR TITLE
ci: build `py3-none` (build.sh) recipes on a single Python leg

### DIFF
--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -10,10 +10,8 @@ on:
         type: string
       canonical_python:
         description: |
-          The single Python version on which Python-independent recipes (those with a
-          build.sh -> py3-none-<plat> wheel) are built. On any other leg those recipes
-          are skipped, since their wheels are identical across versions and the extra
-          legs only emit publish-time duplicates. Empty = no gating (build everything).
+          Python version on which build.sh (py3-none) recipes are built; other legs
+          skip them as identical duplicates. Empty = no gating (build everything).
         required: false
         type: string
         default: ""
@@ -68,9 +66,8 @@ on:
         default: "3.12"
       canonical_python:
         description: |
-          The single Python version on which Python-independent recipes (those with a
-          build.sh -> py3-none-<plat> wheel) are built. Leave empty for a standalone
-          dispatch (no gating — build every recipe on this version):
+          Python version on which build.sh (py3-none) recipes are built; other legs
+          skip them. Leave empty for a standalone dispatch (no gating):
         required: false
         default: ""
       archs:
@@ -117,6 +114,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      has_jobs: ${{ steps.set-matrix.outputs.has_jobs }}
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -132,16 +130,32 @@ jobs:
           INPUT_ARCHS: ${{ inputs.archs }}
           INPUT_PACKAGES: ${{ inputs.packages }}
           INPUT_PYTHON_VERSION: ${{ inputs.python_version }}
+          INPUT_CANONICAL_PYTHON: ${{ inputs.canonical_python }}
         run: |
           ARCHS="$INPUT_ARCHS"
           PACKAGES="$INPUT_PACKAGES"
           py="$INPUT_PYTHON_VERSION"
           py_short="$(echo "$py" | cut -d. -f1-2)"   # 3.12 or 3.12.13 -> 3.12
+          canonical="$INPUT_CANONICAL_PYTHON"        # empty => no gating
+
+          # build.sh recipes -> py3-none wheels, identical on every leg, so build them
+          # only on the canonical one. Decided once per package, before the arch x platform
+          # expansion (so each skip logs once; the survivors may be empty).
+          build_packages=""
+          for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
+            pkg_name="${pkg%%:*}"
+            if [[ -n "$canonical" && "$py_short" != "$canonical" \
+                  && -f "recipes/$pkg_name/build.sh" ]]; then
+              echo "::notice::Skip py${py_short}: ${pkg_name} — py3-none recipe, built only on py${canonical}"
+              continue
+            fi
+            build_packages="${build_packages:+$build_packages }$pkg"
+          done
 
           matrix='{"include":['
           first=true
           for arch in $(echo "$ARCHS" | tr ',' ' '); do
-            for pkg in $(echo "$PACKAGES" | tr ',' ' '); do
+            for pkg in $build_packages; do
               pkg_name="${pkg%%:*}"
               if [[ "$arch" == "android" ]]; then
                 runner="ubuntu-latest"
@@ -179,8 +193,17 @@ jobs:
           matrix+=']}'
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
 
+          # An all-py3-none non-canonical leg yields an empty include; flag it so the
+          # build job is skipped rather than fed an empty matrix.
+          if [[ "$matrix" == '{"include":[]}' ]]; then
+            echo "has_jobs=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_jobs=true" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
     needs: setup
+    if: ${{ needs.setup.outputs.has_jobs == 'true' }}  # Skip legs with no jobs (e.g. an all-py3-none non-canonical leg).
     name: ${{ matrix.job_name }}
     runs-on: ${{ matrix.runner }}
     strategy:

--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -8,6 +8,15 @@ on:
           Python version:
         required: true
         type: string
+      canonical_python:
+        description: |
+          The single Python version on which Python-independent recipes (those with a
+          build.sh -> py3-none-<plat> wheel) are built. On any other leg those recipes
+          are skipped, since their wheels are identical across versions and the extra
+          legs only emit publish-time duplicates. Empty = no gating (build everything).
+        required: false
+        type: string
+        default: ""
       archs:
         description: |
           Architectures (comma-separated):
@@ -57,6 +66,13 @@ on:
           - "3.13"
           - "3.14"
         default: "3.12"
+      canonical_python:
+        description: |
+          The single Python version on which Python-independent recipes (those with a
+          build.sh -> py3-none-<plat> wheel) are built. Leave empty for a standalone
+          dispatch (no gating — build every recipe on this version):
+        required: false
+        default: ""
       archs:
         description: |
           Architectures (comma-separated):

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -91,6 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pythons_json: ${{ steps.detect-pythons.outputs.pythons_json }}
+      canonical_python: ${{ steps.detect-pythons.outputs.canonical_python }}
       packages: ${{ steps.detect-packages.outputs.packages }}
     steps:
       - name: Checkout
@@ -167,6 +168,7 @@ jobs:
     uses: ./.github/workflows/build-wheels-version.yml
     with:
       python_version: ${{ matrix.python_version }}
+      canonical_python: ${{ needs.detect.outputs.canonical_python }}
       archs: ${{ inputs.archs || 'android,iOS' }}
       packages: ${{ needs.detect.outputs.packages }}
       prebuild_recipes: ${{ inputs.prebuild_recipes || '' }}

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -126,6 +126,11 @@ jobs:
           echo "Detected pythons: $pythons -> $json"
           echo "pythons_json=$json" >> "$GITHUB_OUTPUT"
 
+          # Canonical leg = first listed Python. build.sh (py3-none) recipes are
+          # identical on every leg, so they build only on the canonical one.
+          canonical="$(echo "$pythons" | tr ',' ' ' | awk '{print $1}' | cut -d. -f1-2)"
+          echo "canonical_python=$canonical" >> "$GITHUB_OUTPUT"
+
       - id: detect-packages
         shell: bash
         env:


### PR DESCRIPTION
## Problem

`flet-lib*` recipes (libpq, libzbar, libmupdf, …) are native C libraries: a recipe with a `build.sh` routes to forge's `SimplePackageBuilder`, whose wheel tag is [hardcoded](https://github.com/flet-dev/mobile-forge/blob/8ef8c36be4579cb37d84dd64025d78b78fa4867b/src/forge/build.py#L644) `py3-none-<platform>` — versus the `cp3XX-cp3XX` tag real C-extension recipes get from `PythonPackageBuilder`.

A `py3-none` wheel is byte-identical regardless of which Python built it. But the matrix fans every recipe across `3.12,3.13,3.14`, so each of these libs is built three times, producing three identical wheel filenames. Publishing is per-leg, so only the first upload lands and the other two are dismissed as duplicates — two wasted build legs per `py3-none` recipe, every run.

## Change

Build `py3-none` recipes on a single **canonical** leg (the first Python in the list, computed in `detect` and passed to the reusable workflow). Real `cp3XX` extensions are unaffected and still build on every leg.

- `build-wheels.yml`: `detect` computes `canonical_python` (first listed, normalized `X.Y`) and passes it to the build job.
- `build-wheels-version.yml`: new optional `canonical_python` input (default `""` = no gating); `set-matrix` drops `build.sh` recipes on non-canonical legs (one `::notice::` per skip); a `has_jobs` output + `if:` guard skip a leg whose matrix ends up empty (e.g. a change touching only `flet-lib*` recipes).

The gate keys off `build.sh` presence — the exact signal forge itself uses to pick the builder (src/forge/package.py:116), so CI can't disagree with the wheel tag.

## Effect

A PR touching one `flet-lib*` recipe drops from 6 build jobs → 2 (frees a scarce macOS/iOS runner); a full `ALL` run sheds ~80–90 jobs. Applies to every trigger (push, PR, dispatch). `cp3XX` extensions keep building on all three Pythons.

## Backward compatibility

`canonical_python` is optional with an empty default, so standalone `build-wheels-version.yml` dispatches and any cross-repo callers are unchanged (empty = no gating).

## Verification

[Workflow dispatch](https://github.com/ndonkoHenri/mobile-forge/actions/runs/28328286117) (`flet-libpq:,lru-dict:`): `flet-libpq` built only on 3.12; `lru-dict` on all three. Annotations confirmed: `Skip py3.13: flet-libpq — py3-none recipe, built only on py3.12`.

## Tradeoff

The redundant builds were incidental fault-tolerance — a flaky leg was masked by another publishing the identical wheel. Now each `py3-none` wheel publishes from one leg, so a canonical-leg failure blocks that recipe's publish until a re-run. Low risk: wheels are byte-identical, failures are visible (run goes red), and a re-run republishes the same artifact.