### PR TITLE
feat: support `armeabi-v7a` for Python 3.13/3.14

### DIFF
--- a/.github/workflows/build-wheels-version.yml
+++ b/.github/workflows/build-wheels-version.yml
@@ -160,7 +160,7 @@ jobs:
               if [[ "$arch" == "android" ]]; then
                 runner="ubuntu-latest"
                 platform="android"
-                rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android,i686-linux-android"
+                rust_targets="aarch64-linux-android,arm-linux-androideabi,x86_64-linux-android"
               else
                 runner="macos-26"
                 platform="ios"

--- a/make_dep_wheels.py
+++ b/make_dep_wheels.py
@@ -56,9 +56,12 @@ def get_dependencies(os_name):
 
 def get_targets(os_name):
     if os_name == "android":
-        if sys.version_info[:2] >= (3, 13):
-            return ["arm64-v8a", "x86_64"]
-        return ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
+        # ABIs come from python-build's manifest via $ANDROID_ABIS (exported by setup.sh).
+        # Fall back to the all abis when invoked without setup.sh's environment.
+        abis = os.environ.get("ANDROID_ABIS")
+        if abis:
+            return abis.split()
+        return ["arm64-v8a", "armeabi-v7a", "x86_64"]
     return [
         "iphoneos.arm64",
         "iphonesimulator.arm64",
@@ -84,7 +87,9 @@ def make_wheel(package, os_name, target):
     package_version_build = re.search(
         rf"^{package}: (.*)", versions, re.MULTILINE | re.IGNORECASE
     )[1]
-    min_version = re.search(rf"^Min {os_name} version: (.*)", versions, re.MULTILINE | re.IGNORECASE)[1]
+    min_version = re.search(
+        rf"^Min {os_name} version: (.*)", versions, re.MULTILINE | re.IGNORECASE
+    )[1]
 
     package_version, package_build = package_version_build.split("-")
 

--- a/make_dep_wheels.py
+++ b/make_dep_wheels.py
@@ -56,8 +56,8 @@ def get_dependencies(os_name):
 
 def get_targets(os_name):
     if os_name == "android":
-        # ABIs come from python-build's manifest via $ANDROID_ABIS (exported by setup.sh).
-        # Fall back to the all abis when invoked without setup.sh's environment.
+        # setup.sh reads the ABI set from the pinned python-build release's manifest and exports it
+        # as env var; while falling back to all 3 abis when forge is invoked without sourcing setup.sh.
         abis = os.environ.get("ANDROID_ABIS")
         if abis:
             return abis.split()

--- a/setup.sh
+++ b/setup.sh
@@ -75,10 +75,7 @@ resolve_full_version() {
 }
 
 # Echo the space-separated Android ABI set for a bare X.Y minor, read from the same
-# pinned-release manifest (`pythons.<minor>.android_abis`) — the single source of truth
-# shared with python-build's own build-all.sh / packaging. Same 3-tier parser as
-# resolve_full_version (jq -> python3 -> scoped sed) so it works on a bare machine.
-# Returns non-zero (empty) if the fetch or lookup fails.
+# pinned python-build release manifest. Returns non-zero (empty) if the fetch or lookup fails.
 resolve_android_abis() {
     local minor="$1"
     local mf="downloads/python-build-manifest-${PYTHON_BUILD_RELEASE}.json"
@@ -132,9 +129,8 @@ echo "Python version: $PYTHON_VERSION"
 echo "Python short version: $PYTHON_VER"
 echo "python-build release: $PYTHON_BUILD_RELEASE"
 
-# Android ABI set for this minor, from the python-build manifest. Overridable via env (e.g. CI validating
-# a python-build branch via PYTHON_BUILD_RUN_ID whose ABI set differs from the pinned release). cross.py and
-# make_dep_wheels.py read $ANDROID_ABIS and fall back to the same default if it's unset.
+# Android ABI set for this minor, from the python-build manifest.
+# Overridable by setting ANDROID_ABIS env var.
 ANDROID_ABIS="${ANDROID_ABIS:-$(resolve_android_abis "$PYTHON_VER")}"
 if [ -z "$ANDROID_ABIS" ]; then
     ANDROID_ABIS="arm64-v8a x86_64 armeabi-v7a"

--- a/setup.sh
+++ b/setup.sh
@@ -34,7 +34,7 @@ if ! command -v uv &> /dev/null; then
 fi
 
 # Pinned flet-dev/python-build release to consume (date-keyed YYYYMMDD, PBS-style).
-PYTHON_BUILD_RELEASE="${PYTHON_BUILD_RELEASE:-20260614}"
+PYTHON_BUILD_RELEASE="${PYTHON_BUILD_RELEASE:-20260629}"
 
 # Resolve a full X.Y.Z from a bare X.Y minor using the pinned release's
 # manifest.json (downloaded + cached under downloads/). Echoes the full version;
@@ -74,6 +74,45 @@ resolve_full_version() {
     echo "$full"
 }
 
+# Echo the space-separated Android ABI set for a bare X.Y minor, read from the same
+# pinned-release manifest (`pythons.<minor>.android_abis`) — the single source of truth
+# shared with python-build's own build-all.sh / packaging. Same 3-tier parser as
+# resolve_full_version (jq -> python3 -> scoped sed) so it works on a bare machine.
+# Returns non-zero (empty) if the fetch or lookup fails.
+resolve_android_abis() {
+    local minor="$1"
+    local mf="downloads/python-build-manifest-${PYTHON_BUILD_RELEASE}.json"
+    local murl="https://github.com/flet-dev/python-build/releases/download/${PYTHON_BUILD_RELEASE}/manifest.json"
+
+    mkdir -p downloads
+    if [ ! -f "$mf" ]; then
+        if ! curl -fsSL -o "$mf" "$murl"; then
+            echo "Failed to fetch python-build manifest ($murl)." >&2
+            rm -f "$mf"
+            return 1
+        fi
+    fi
+
+    local abis=""
+    if command -v jq >/dev/null 2>&1; then
+        abis="$(jq -r --arg m "$minor" '.pythons[$m].android_abis // [] | join(" ")' "$mf" 2>/dev/null)"
+    elif command -v python3 >/dev/null 2>&1; then
+        abis="$(python3 -c 'import json,sys; print(" ".join(json.load(open(sys.argv[1])).get("pythons",{}).get(sys.argv[2],{}).get("android_abis",[])))' "$mf" "$minor" 2>/dev/null)"
+    else
+        # Scope to the minor's block, then to the android_abis array, and collect the
+        # quoted ABI tokens (dropping the "android_abis" key token itself).
+        local minor_re="${minor//./[.]}"
+        abis="$(sed -n "/\"$minor_re\"[[:space:]]*:/,/}/p" "$mf" \
+            | sed -n '/"android_abis"/,/]/p' \
+            | grep -oE '"[a-z0-9_-]+"' | tr -d '"' \
+            | grep -vx 'android_abis' | tr '\n' ' ')"
+    fi
+
+    [ -n "$abis" ] || return 1
+    # Trim trailing whitespace.
+    echo "$abis" | xargs
+}
+
 # Accept either a full X.Y.Z or a bare X.Y minor as $1. Derive the X.Y minor either
 # way (cut handles both forms); when only the minor is given, resolve the patch from
 # the pinned release's manifest. A full version is taken as-is (works offline and for
@@ -92,6 +131,17 @@ fi
 echo "Python version: $PYTHON_VERSION"
 echo "Python short version: $PYTHON_VER"
 echo "python-build release: $PYTHON_BUILD_RELEASE"
+
+# Android ABI set for this minor, from the python-build manifest. Overridable via env (e.g. CI validating
+# a python-build branch via PYTHON_BUILD_RUN_ID whose ABI set differs from the pinned release). cross.py and
+# make_dep_wheels.py read $ANDROID_ABIS and fall back to the same default if it's unset.
+ANDROID_ABIS="${ANDROID_ABIS:-$(resolve_android_abis "$PYTHON_VER")}"
+if [ -z "$ANDROID_ABIS" ]; then
+    ANDROID_ABIS="arm64-v8a x86_64 armeabi-v7a"
+    echo "Warning: manifest has no android_abis for $PYTHON_VER; defaulting to: $ANDROID_ABIS" >&2
+fi
+export ANDROID_ABIS
+echo "Android ABIs: $ANDROID_ABIS"
 
 # Download (and cache) a mobile-forge Python support package, extracting it
 # into $2. Source is either the pinned date-keyed ($PYTHON_BUILD_RELEASE) release
@@ -327,29 +377,15 @@ if [ ! -z "$MOBILE_FORGE_IOS_SUPPORT_PATH" ]; then
     echo "MOBILE_FORGE_IOS_SUPPORT_PATH: $MOBILE_FORGE_IOS_SUPPORT_PATH"
 fi
 
-# configure Android paths
+# configure Android paths — every ABI the manifest declares for this
+# minor must have a device binary in the support tree
 if [ ! -z "$MOBILE_FORGE_ANDROID_SUPPORT_PATH" ]; then
-    if [ ! -e $MOBILE_FORGE_ANDROID_SUPPORT_PATH/install/android/arm64-v8a/python-$PYTHON_VERSION/bin/python$PYTHON_VER ]; then
-        echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH does not appear to contain a Python $PYTHON_VERSION Android arm64-v8a device binary."
-        return
-    fi
-
-    if [ ! -e $MOBILE_FORGE_ANDROID_SUPPORT_PATH/install/android/x86_64/python-$PYTHON_VERSION/bin/python$PYTHON_VER ]; then
-        echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH does not appear to contain a Python $PYTHON_VERSION Android x86_64 device binary."
-        return
-    fi
-
-    if [ "$python_version_minor" -lt 13 ]; then
-        if [ ! -e $MOBILE_FORGE_ANDROID_SUPPORT_PATH/install/android/armeabi-v7a/python-$PYTHON_VERSION/bin/python$PYTHON_VER ]; then
-            echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH does not appear to contain a Python $PYTHON_VERSION Android armeabi-v7a device binary."
+    for abi in $ANDROID_ABIS; do
+        if [ ! -e "$MOBILE_FORGE_ANDROID_SUPPORT_PATH/install/android/$abi/python-$PYTHON_VERSION/bin/python$PYTHON_VER" ]; then
+            echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH does not appear to contain a Python $PYTHON_VERSION Android $abi device binary."
             return
         fi
-
-        if [ ! -e $MOBILE_FORGE_ANDROID_SUPPORT_PATH/install/android/x86/python-$PYTHON_VERSION/bin/python$PYTHON_VER ]; then
-            echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH does not appear to contain a Python $PYTHON_VERSION Android x86 device binary."
-            return
-        fi
-    fi
+    done
 
     echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH: $MOBILE_FORGE_ANDROID_SUPPORT_PATH"
 fi
@@ -362,6 +398,7 @@ if [ -n "${GITHUB_ENV:-}" ]; then
     {
         echo "MOBILE_FORGE_IOS_SUPPORT_PATH=$MOBILE_FORGE_IOS_SUPPORT_PATH"
         echo "MOBILE_FORGE_ANDROID_SUPPORT_PATH=$MOBILE_FORGE_ANDROID_SUPPORT_PATH"
+        echo "ANDROID_ABIS=$ANDROID_ABIS"
     } >> "$GITHUB_ENV"
 fi
 

--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -20,9 +20,8 @@ class CrossVEnv:
         "watchOS": "4.0",
     }
 
-    # The Android ABI set is python-build's manifest. setup.sh reads it from the pinned
-    # release's manifest and exports it as $ANDROID_ABIS; this falls back to all 3 abis
-    # when forge is invoked without sourcing setup.sh.
+    # setup.sh reads the ABI set from the pinned python-build release's manifest and exports it
+    # as env var; while falling back to all 3 abis when forge is invoked without sourcing setup.sh.
     ANDROID_HOST_ARCHS = (
         tuple(os.environ["ANDROID_ABIS"].split())
         if os.environ.get("ANDROID_ABIS")

--- a/src/forge/cross.py
+++ b/src/forge/cross.py
@@ -20,10 +20,13 @@ class CrossVEnv:
         "watchOS": "4.0",
     }
 
+    # The Android ABI set is python-build's manifest. setup.sh reads it from the pinned
+    # release's manifest and exports it as $ANDROID_ABIS; this falls back to all 3 abis
+    # when forge is invoked without sourcing setup.sh.
     ANDROID_HOST_ARCHS = (
-        ("arm64-v8a", "x86_64")
-        if sys.version_info[:2] >= (3, 13)
-        else ("arm64-v8a", "armeabi-v7a", "x86_64", "x86")
+        tuple(os.environ["ANDROID_ABIS"].split())
+        if os.environ.get("ANDROID_ABIS")
+        else ("arm64-v8a", "armeabi-v7a", "x86_64")
     )
 
     HOST_SDKS = {


### PR DESCRIPTION
Companion to flet-dev/python-build#25, which added `armeabi-v7a` (32-bit ARM) runtimes for Python 3.13/3.14. That release (**20260629**) now ships `["arm64-v8a", "x86_64", "armeabi-v7a"]` for **all three** minors, and drops `x86` (32-bit Intel) everywhere.

This PR teaches mobile-forge to consume that: it makes the Android ABI set **manifest-driven** here too, so the same single source of truth flows across both repos and a future ABI change upstream needs only a release-pin bump here — no hardcoded list to keep in sync.

Net effect: forge now builds **armeabi-v7a wheels for 3.13/3.14** (it already did for 3.12), and stops building the now-unshipped **x86**.

## Changes

- **`setup.sh`**
  - Bump `PYTHON_BUILD_RELEASE` `20260614` → `20260629`.
  - New `resolve_android_abis()` — reads `pythons.<minor>.android_abis` from the pinned release's manifest using the same 3-tier parser as `resolve_full_version` (jq → python3 → scoped sed, cached under `downloads/`). Exports **`ANDROID_ABIS`** (env-overridable for the `PYTHON_BUILD_RUN_ID` branch-validation path; also pushed to `GITHUB_ENV`).
  - Android support-tree verification now **loops `$ANDROID_ABIS`** instead of the  hardcoded `minor < 13 → check armeabi+x86` gate.
- **`src/forge/cross.py`** — `ANDROID_HOST_ARCHS` reads `$ANDROID_ABIS` (falls back to
  `("arm64-v8a", "armeabi-v7a", "x86_64")` when forge runs without sourcing setup.sh), replacing the `>=3.13 → 64-bit-only` version gate.
- **`make_dep_wheels.py`** — `get_targets("android")` reads `$ANDROID_ABIS` too, so the support-tree dep wheels (openssl/libffi/sqlite/xz/…) get produced for armeabi-v7a on 3.13/3.14.
- **`.github/workflows/build-wheels-version.yml`** — drop the now-dead `i686-linux-android` Rust target (`arm-linux-androideabi` for armeabi was already present).

No change needed elsewhere: `cross.py` already maps armeabi-v7a → `android-arm` (3.13+ official-build naming) and the wheel tag is the version-independent `android_24_armeabi_v7a`; the CI matrix keys on `android`/`iOS` (per-ABI fan-out happens inside forge); the support-tree dep-wheel drop step is ABI-agnostic.

## Behavioral note: x86 is dropped

`20260629` ships no `x86` runtime for any minor (the mobile-forge tarball is `tar install support` right after `build-all.sh`, which builds only the manifest's ABIs). So bumping the pin necessarily stops x86 wheel production for 3.12 too. Already-published 3.12 x86 wheels become orphaned on the index — harmless, since flet/serious_python don't ship 32-bit Intel.

## Validation

Verified locally:
- All three manifest-parser tiers (jq / python3 / sed) return `arm64-v8a x86_64 armeabi-v7a` for 3.12/3.13/3.14 against the real 20260629 manifest.
- `ANDROID_HOST_ARCHS` / `get_targets` honor `$ANDROID_ABIS` and fall back correctly.
- armeabi-v7a → `_platform_identifier` `android-arm`, tag `android_24_armeabi_v7a`.
- The support-tree binary path the verify loop checks (`install/android/<abi>/python-<full>/bin/python<minor>`) matches the tarball layout.
- `bash -n` + `py_compile` clean; no new lint/format findings.

Full validation comes via the follow-up `packages=ALL` build across python versions.
