### PR TITLE
fix: normalize dotted distribution names in wheel METADATA

### DIFF
--- a/src/forge/build.py
+++ b/src/forge/build.py
@@ -800,6 +800,32 @@ class Builder(ABC):
             for so in wheel_dir.glob("**/*.so"):
                 self._check_elf_alignment(so)
 
+        # Normalize a dotted distribution name (e.g. "zope.interface" -> "zope-interface")
+        # to its PEP 503 canonical form in the wheel METADATA. pypi.flet.dev (Gemfury)
+        # returns 409 "version already exists" for every wheel after the first when the
+        # METADATA Name contains dots, so a dotted-name package could otherwise only ever
+        # publish ONE platform wheel per version. We rewrite just the `Name:` header (a
+        # targeted text edit that preserves the rest of METADATA, including the
+        # long-description body that the message round-trip below would drop); the wheel
+        # filename, .dist-info dir and import name are already dot-free, and pip treats the
+        # dotted and normalized names as equivalent so dependents resolve transparently.
+        metadata_path = next(wheel_dir.glob("*.dist-info")) / "METADATA"
+        metadata_text = metadata_path.read_text(encoding="utf-8")
+        name_match = re.search(r"(?m)^Name:[ \t]*(.+?)[ \t]*$", metadata_text)
+        if name_match and "." in name_match[1]:
+            normalized = canonicalize_name(name_match[1])
+            log(
+                self.log_file,
+                f"[{self.cross_venv}] Normalizing dotted dist name "
+                f"{name_match[1]!r} -> {normalized!r} in METADATA",
+            )
+            metadata_path.write_text(
+                metadata_text[: name_match.start()]
+                + f"Name: {normalized}"
+                + metadata_text[name_match.end() :],
+                encoding="utf-8",
+            )
+
         # add missing requirements from "host"
         if len(self.package.meta["requirements"]["host"]):
             metadata_path = next(wheel_dir.glob("*.dist-info")) / "METADATA"


### PR DESCRIPTION
Packages whose **distribution name contains dots** — `zope.interface`, `ruamel.yaml.clib` (and any future `backports.*` / `jaraco.*` style recipe) — build wheels whose METADATA `Name:` field keeps the dots. Gemfury (pypi.flet.dev) then returns **`409 "version already exists"` for every wheel after the first** uploaded for a given version, so a dotted-name package can only ever hold **one platform wheel per version** — the rest are silently dropped (the publish step counts the 409 as "already exists").

This is exactly what broke `zope.interface` and `ruamel.yaml.clib`: their versions had a single `cp312-arm64` wheel on the index and nothing else, while dash-named packages (`google-crc32c`, `argon2-cffi-bindings`, …) publish their full multi-platform set without issue.

## Change

Fix it once in the build engine instead of per recipe. In `Builder.fix_wheel()` (`src/forge/build.py`), when the wheel METADATA `Name:` contains a dot, rewrite it to its PEP 503 canonical form via `packaging.canonicalize_name` (already imported):

- `zope.interface` → `zope-interface`
- `ruamel.yaml.clib` → `ruamel-yaml-clib`

Implementation notes:
- It's a **targeted text edit of just the `Name:` header**, not the `read/write_message_file` round-trip used for requirements injection — that round-trip drops the METADATA long-description body, which we don't want here.
- The existing `wheel pack` repack regenerates `RECORD`, so the edit is install-valid.
- **Gated on a dot in the name**, so the ~70 dot-free recipes (incl. `MarkupSafe`) are completely untouched.

Only the METADATA `Name:` changes — the wheel **filename**, **`.dist-info` dir** and **import name** are already dot-free, and pip normalizes the dotted and canonical names equivalently, so dependents resolve `zope.interface` ↔ `zope-interface` transparently.

## Validation

End-to-end on a real dotted wheel, through forge's exact `wheel unpack → edit → wheel pack` path:
- `Name: zope.interface` → `Name: zope-interface`
- long-description body preserved; `RECORD` regenerated and valid
- installs, resolves under **both** names, and `import zope.interface` works

Confirmed in the real cross-compile pipeline too: `zope.interface` published its full 18-wheel set (cp312/313/314 × all android ABIs + iOS) once the name was normalized — vs. 1 wheel before — and passed on-device mobile tests (3.12 android emulator + iOS simulator).