### PR TITLE
recipe: xxhash 3.8.0 + ormsgpack 1.12.2

### DIFF
--- a/recipes/ormsgpack/meta.yaml
+++ b/recipes/ormsgpack/meta.yaml
@@ -1,0 +1,8 @@
+package:
+  name: ormsgpack
+  version: '1.12.2'
+
+build:
+  number: 1
+  script_env:
+    _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'

--- a/recipes/ormsgpack/test_ormsgpack.py
+++ b/recipes/ormsgpack/test_ormsgpack.py
@@ -1,0 +1,15 @@
+def test_basic():
+    """Confirm the Rust extension loads and round-trips a msgpack payload."""
+    import ormsgpack
+
+    payload = {
+        "library": "ormsgpack",
+        "active": True,
+        "tags": ["mobile", "python", "flet"],
+        "ratio": 3.141592653589793,
+        "nothing": None,
+    }
+
+    packed = ormsgpack.packb(payload)
+    assert isinstance(packed, bytes)  # ormsgpack returns bytes
+    assert ormsgpack.unpackb(packed) == payload

--- a/recipes/xxhash/meta.yaml
+++ b/recipes/xxhash/meta.yaml
@@ -1,0 +1,6 @@
+package:
+  name: xxhash
+  version: '3.8.0'
+
+build:
+  number: 1

--- a/recipes/xxhash/test_xxhash.py
+++ b/recipes/xxhash/test_xxhash.py
@@ -1,0 +1,13 @@
+def test_basic():
+    """Load the bundled xxHash C extension and verify a known digest."""
+    import xxhash
+
+    # xxh64 of the empty string with the default seed 0 — a stable,
+    # documented vector. Proves the C extension computes correctly.
+    assert xxhash.xxh64_intdigest(b"") == 0xEF46DB3751D8E999
+
+    # Same input -> same digest, across both the streaming and one-shot APIs.
+    h = xxhash.xxh3_64()
+    h.update(b"mobile-forge")
+    assert h.hexdigest() == xxhash.xxh3_64_hexdigest(b"mobile-forge")
+    assert isinstance(xxhash.VERSION, str)  # bundled libxxhash version


### PR DESCRIPTION
Adds two recipes requested in flet-dev/flet#6625 to support **LangGraph** on mobile:

- **xxhash 3.8.0** — fast hashing (LangGraph uses it for cache keys)
- **ormsgpack 1.12.2** — msgpack (de)serialization

## Recipe shapes — both clean, no patches

- **xxhash** — minimal C-extension (`setuptools`, bundles the xxHash C source; sdist ships the prebuilt `_xxhash.c`, so no Cython at build). Upstream already cross-compiles to mobile, but only publishes **cp313/cp314** wheels and **no armeabi-v7a** — this recipe fills the gaps (cp312, which is flet's primary, plus armeabi-v7a) and puts the full set on pypi.flet.dev.
- **ormsgpack** — Rust / PyO3 via maturin, mirroring the existing `orjson` recipe (just `_PYTHON_SYSCONFIGDATA_NAME` for the PyO3 cross-build). Stable toolchain (rust-version 1.81, `unstable-simd` off by default), so no nightly. The 32-bit **armeabi-v7a** build needed no `AtomicU64`/`portable_atomic` workaround.