### PR TITLE
recipe: scikit-learn 1.9.0 + flet-libomp

### DIFF
--- a/recipes/flet-libomp/build.sh
+++ b/recipes/flet-libomp/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -eu
+
+if [[ "$CROSS_VENV_SDK" != "android" ]]; then
+    echo "This package can be built for Android only."
+    exit 1
+fi
+
+# libomp.so lives in clang's per-target runtime dir, keyed by the LLVM arch name
+# (not the Android ABI): arm64-v8a->aarch64, armeabi-v7a->arm, x86_64->x86_64,
+# x86->i386. This is the same libomp.so the toolchain links with -fopenmp.
+case "$HOST_ARCH" in
+    arm64-v8a)   omp_arch=aarch64 ;;
+    armeabi-v7a) omp_arch=arm ;;
+    x86_64)      omp_arch=x86_64 ;;
+    x86)         omp_arch=i386 ;;
+    *) echo "flet-libomp: unsupported arch '$HOST_ARCH'"; exit 1 ;;
+esac
+
+toolchain=$(echo "$NDK_ROOT"/toolchains/llvm/prebuilt/*)
+libomp=$(echo "$toolchain"/lib/clang/*/lib/linux/"$omp_arch"/libomp.so)
+
+if [ ! -f "$libomp" ]; then
+    echo "flet-libomp: libomp.so not found at $libomp"
+    exit 1
+fi
+
+mkdir -p "$PREFIX/lib"
+cp "$libomp" "$PREFIX/lib/libomp.so"

--- a/recipes/flet-libomp/meta.yaml
+++ b/recipes/flet-libomp/meta.yaml
@@ -1,0 +1,14 @@
+package:
+  name: flet-libomp
+  version: 27.3.13750724
+  # libomp.so is the LLVM OpenMP runtime, extracted from the NDK's clang and repackaged so Android
+  # apps can bundle it. Any OpenMP C-extension (e.g. scikit-learn) links `-lomp` → a `libomp.so`
+  # DT_NEEDED that must be present at runtime. Meaningless on iOS — Apple clang ships no OpenMP,
+  # so those builds fall back to single-threaded and never reference libomp.
+  platforms: [android]
+
+build:
+  number: 1
+
+source:
+  url: https://github.com/flet-dev/awesome-flet/archive/refs/heads/main.zip

--- a/recipes/scikit-learn/meta.yaml
+++ b/recipes/scikit-learn/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: scikit-learn
+  version: '1.9.0'
+
+build:
+  number: 1
+  backend-args:
+    # scikit-learn borrows BLAS via scipy.linalg.cython_blas (no external BLAS
+    # link, no Fortran); OpenMP is optional (required:false → single-threaded).
+    - -Csetup-args=--cross-file
+    - -Csetup-args={MESON_CROSS_FILE}
+
+requirements:
+  build:
+    - ninja
+    - meson
+    - cython
+  host:
+    - numpy 2.4.6
+    - scipy 1.18.0
+# {% if sdk == 'android' %}
+    # scikit-learn vendors C++ (libsvm/liblinear/newrand) → libc++_shared.so, and
+    # links OpenMP → libomp.so; both are NDK runtime libs the app must bundle.
+    # (iOS has no OpenMP, so it builds single-threaded and needs neither)
+    - flet-libcpp-shared >=27.2.12479018
+    - flet-libomp 27.3.13750724
+# {% endif %}
+
+patches:
+  - relax-scipy-build-cap.patch
+  - disable-openmp-non-android.patch
+  - ios-guard-multiprocessing-import.patch

--- a/recipes/scikit-learn/patches/disable-openmp-non-android.patch
+++ b/recipes/scikit-learn/patches/disable-openmp-non-android.patch
@@ -1,0 +1,23 @@
+# On iOS, Apple clang reports OpenMP as found (its -fopenmp probe compiles), but
+# there is no libomp to link, so scikit-learn's OpenMP extensions fail at link.
+# Gate openmp_dep to Android only (where the NDK ships libomp and flet-libomp
+# bundles it at runtime); non-Android targets build single-threaded — the same
+# fallback scikit-learn already supports on plain macOS.
+--- a/sklearn/meson.build
+--- a/sklearn/meson.build
++++ b/sklearn/meson.build
+@@ -102,6 +102,14 @@
+ np_dep = declare_dependency(include_directories: inc_np, compile_args: numpy_no_deprecated_api)
+ 
+ openmp_dep = dependency('OpenMP', language: 'c', required: false)
++
++if host_machine.system() != 'android'
++  # mobile-forge: Apple clang's -fopenmp detection passes on iOS, but there is no
++  # libomp to link against there, so the OpenMP extensions fail to link. Force
++  # single-threaded on non-Android targets. Android keeps OpenMP (the NDK ships
++  # libomp, bundled at runtime by the flet-libomp recipe).
++  openmp_dep = dependency('openmp-force-off-non-android', required: false)
++endif
+ 
+ if not openmp_dep.found()
+   warn_about_missing_openmp = true

--- a/recipes/scikit-learn/patches/ios-guard-multiprocessing-import.patch
+++ b/recipes/scikit-learn/patches/ios-guard-multiprocessing-import.patch
@@ -1,0 +1,26 @@
+# scikit-learn 1.9's sklearn.callback._transport unconditionally imports
+# multiprocessing.connection at module load (for cross-process progress bars),
+# pulling in the _multiprocessing C-extension. CPython disables _multiprocessing
+# (and _posixsubprocess) on iOS — the app sandbox forbids spawning child processes,
+# so process-based parallelism is impossible there — so importing any sklearn
+# submodule crashes on iOS with ModuleNotFoundError. The transport is only reached
+# under multiprocessing parallelism (never on single-process mobile); guard the
+# import so scikit-learn stays importable. No-op on Android (ships _multiprocessing).
+--- a/sklearn/callback/_transport.py
++++ b/sklearn/callback/_transport.py
+@@ -18,7 +18,14 @@
+ 
+ import os
+ import weakref
+-from multiprocessing.connection import Client, Connection, Listener
++try:
++    from multiprocessing.connection import Client, Connection, Listener
++except ImportError:
++    # flet's iOS Python ships no _multiprocessing C-extension. This cross-process
++    # progress-bar transport is then unusable, but it is only reached with
++    # multiprocessing parallelism (never on single-process mobile), so fall back
++    # to placeholders and keep scikit-learn importable.
++    Client = Connection = Listener = None
+ from threading import Thread
+ from typing import Callable, NamedTuple
+ 

--- a/recipes/scikit-learn/patches/relax-scipy-build-cap.patch
+++ b/recipes/scikit-learn/patches/relax-scipy-build-cap.patch
@@ -1,0 +1,16 @@
+# scikit-learn 1.9.0 pins its build-time scipy to <1.18.0 — a conservative upper
+# bound set before scipy 1.18 was released, not a real incompatibility. mobile-forge
+# ships scipy 1.18.0; without this the build env would install an older desktop scipy
+# whose cython_blas.pxd could diverge from the 1.18.0 the target links against.
+# Bump the cap to <1.19.0 so both use 1.18.
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -102,7 +102,7 @@
+     "meson-python>=0.17.1,<0.20.0",
+     "cython>=3.1.2,<3.3.0",
+     "numpy>=2,<2.5.0",
+-    "scipy>=1.10.0,<1.18.0",
++    "scipy>=1.10.0,<1.19.0",
+ ]
+ 
+ [tool.pytest.ini_options]

--- a/recipes/scikit-learn/test_scikit_learn.py
+++ b/recipes/scikit-learn/test_scikit_learn.py
@@ -1,0 +1,37 @@
+import numpy as np
+
+
+def test_linear_regression():
+    """LinearRegression -> exercises the scipy.linalg (BLAS) solve path."""
+    from sklearn.linear_model import LinearRegression
+
+    x = np.array([[1.0], [2.0], [3.0], [4.0]])
+    y = np.array([2.0, 4.0, 6.0, 8.0])
+    m = LinearRegression().fit(x, y)
+    assert abs(m.coef_[0] - 2.0) < 1e-9
+    assert abs(m.intercept_) < 1e-9
+    assert np.allclose(m.predict([[5.0]]), [10.0])
+
+
+def test_svc():
+    """SVC(linear) -> exercises the vendored libsvm C++ extension."""
+    from sklearn.svm import SVC
+
+    x = np.array([[0.0, 0.0], [0.2, 0.1], [1.0, 1.0], [0.9, 1.1]])
+    y = np.array([0, 0, 1, 1])
+    clf = SVC(kernel="linear").fit(x, y)
+    assert clf.predict([[0.95, 1.0]])[0] == 1
+    assert clf.predict([[0.05, 0.05]])[0] == 0
+
+
+def test_kmeans():
+    """KMeans -> exercises the Cython (+ optional OpenMP) compute path."""
+    from sklearn.cluster import KMeans
+
+    x = np.array([[0.0, 0.0], [0.1, 0.1], [10.0, 10.0], [10.1, 9.9]])
+    km = KMeans(n_clusters=2, n_init=1, random_state=0).fit(x)
+    assert len(set(km.labels_.tolist())) == 2
+    # the two near-origin points share a cluster; the two near-(10,10) share the other
+    assert km.labels_[0] == km.labels_[1]
+    assert km.labels_[2] == km.labels_[3]
+    assert km.labels_[0] != km.labels_[2]


### PR DESCRIPTION
Adds **scikit-learn** (flet-dev/flet#4315, flet-dev/flet#5364) and **flet-libomp**, its OpenMP runtime. The direct payoff of the scipy recipe — scikit-learn rides on the numpy/scipy/OpenBLAS foundation, so there's no new BLAS or Fortran work.

## Approach

- **No external BLAS, no Fortran.** scikit-learn borrows BLAS through `scipy.linalg.cython_blas` at compile time, so it links nothing extra.
- **meson-python/Cython**, the same archetype as numpy/scipy.
- Pure-python deps (joblib, narwhals, threadpoolctl) install from PyPI at build time.

## Recipes

- **`scikit-learn` 1.9.0** — host deps `numpy 2.4.6`, `scipy 1.18.0`, and on Android `flet-libcpp-shared` (vendored libsvm/liblinear/newrand C++) + `flet-libomp` (OpenMP).
- **`flet-libomp`** — new flet-lib (mirrors flet-libcpp-shared): extracts the NDK's `libomp.so` (from clang's per-arch runtime dir) and repackages it so Android apps can bundle it. `platforms: [android]` — iOS has no OpenMP.

## Platform notes

iOS builds single-threaded (Apple clang has no linkable OpenMP). Three platform-guarded patches:

- `relax-scipy-build-cap.patch` — scikit-learn 1.9.0 caps build-time `scipy<1.18.0` (a bound set before 1.18 existed); relax to `<1.19.0` so the build env's scipy (which supplies `cython_blas.pxd`) matches the target's 1.18.0.
- `disable-openmp-non-android.patch` — Apple clang's `-fopenmp` probe passes on iOS but there's no libomp to link, so the OpenMP extensions fail at link; gate `openmp_dep` to Android only (iOS falls back to single-threaded).
- `ios-guard-multiprocessing-import.patch` — `sklearn.callback._transport` imports `multiprocessing.connection` unconditionally at module load, pulling in the `_multiprocessing` C-extension. flet's iOS python doesn't ship it, so importing any sklearn submodule crashes on iOS; guard the import (no-op on Android).