### PR TITLE
recipe: ncnn 1.0.20260526

### DIFF
--- a/recipes/ncnn/meta.yaml
+++ b/recipes/ncnn/meta.yaml
@@ -1,0 +1,60 @@
+package:
+  name: ncnn
+  version: "1.0.20260526"
+
+build:
+  number: 1
+  script_env:
+    _PYTHON_SYSCONFIGDATA_NAME: '{sysconfigdata_name}'
+    # setup.py appends EXTRA_CMAKE_ARGS after its own args, so our overrides
+    # win (it force-enables NCNN_VULKAN=ON -> we turn it back OFF for v1:
+    # CPU/NEON is the mobile baseline; Vulkan needs per-device driver luck).
+    # The vendored pybind11 is v3 = new FindPython -> explicit Python_*
+    # triple (pywhispercpp tell); setup.py's own Python_EXECUTABLE points at
+    # the crossenv python already, the include/lib pins make it airtight.
+# {% if sdk == 'android' %}
+    CMAKE_TOOLCHAIN_FILE: '{NDK_ROOT}/build/cmake/android.toolchain.cmake'
+    EXTRA_CMAKE_ARGS: >-
+      -DANDROID_ABI={ANDROID_ABI}
+      -DANDROID_NATIVE_API_LEVEL={ANDROID_API_LEVEL}
+      -DANDROID_STL=c++_shared
+      -DCMAKE_SHARED_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DCMAKE_MODULE_LINKER_FLAGS=-Wl,-z,max-page-size=16384
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.so
+      -DNCNN_VULKAN=OFF
+# {% else %}
+    # ninja pip pkg crashes importing on the iOS crossenv (duckdb tell).
+    CMAKE_GENERATOR: Unix Makefiles
+    # NCNN_SIMPLEOMP = ncnn's own minimal OpenMP runtime, designed for
+    # exactly this case (AppleClang has no -fopenmp); threading works
+    # without any libomp. Android keeps real NDK OpenMP instead.
+    EXTRA_CMAKE_ARGS: >-
+      -DCMAKE_SYSTEM_NAME=iOS
+      -DCMAKE_OSX_SYSROOT={{ sdk }}
+      -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
+      -DCMAKE_OSX_ARCHITECTURES={{ arch }}
+      -DPython_EXECUTABLE={CROSS_VENV_PYTHON}
+      -DPython_INCLUDE_DIR={HOST_PYTHON_HOME}/include/python{py_version_short}
+      -DPython_LIBRARY={HOST_PYTHON_HOME}/lib/libpython{py_version_short}.dylib
+      -DNCNN_VULKAN=OFF
+      -DNCNN_SIMPLEOMP=ON
+# {% endif %}
+
+requirements:
+  build:
+    # setup.py drives CMake directly (pybind11 archetype); seed the shims
+    # for forge's --no-isolation builds (opencv-python precedent).
+    - cmake
+    - ninja
+# {% if sdk == 'android' %}
+  host:
+    # ncnn is C++ -> libc++_shared.so at runtime. OpenMP needs no host dep:
+    # the NDK links libomp STATICALLY here (verified: 124 omp_* symbols
+    # defined in ncnn.so, none undefined).
+    - flet-libcpp-shared >=27.2.12479018
+# {% endif %}
+
+patches:
+  - pin-version-date.patch

--- a/recipes/ncnn/patches/pin-version-date.patch
+++ b/recipes/ncnn/patches/pin-version-date.patch
@@ -1,0 +1,17 @@
+setup.py generates the wheel version as MAJOR.MINOR.<build date>
+(time.strftime("%Y%m%d")), so building the 1.0.20260526 sdist on any other
+day would produce a version that mismatches this recipe's pin (and forge's
+wheel bookkeeping). Pin the date segment to the sdist's own release date.
+
+--- a/setup.py
++++ b/setup.py
+@@ -19,7 +19,8 @@ def find_version():
+     version_minor = re.findall(r"NCNN_VERSION_MINOR (.+?)", version_file)
+
+     if version_major and version_minor:
+-        ncnn_version = time.strftime("%Y%m%d", time.localtime())
++        # mobile-forge: pinned to the sdist release date
++        ncnn_version = "20260526"
+
+         return version_major[0] + "." + version_minor[0] + "." + ncnn_version
+     raise RuntimeError("Unable to find version string.")

--- a/recipes/ncnn/tests/test_ncnn.py
+++ b/recipes/ncnn/tests/test_ncnn.py
@@ -1,0 +1,56 @@
+import os
+
+import numpy as np
+
+# A weightless graph in ncnn's text .param format: Input -> global max
+# Pooling. Real graph execution through the full Net/Extractor machinery
+# with an EMPTY .bin (pooling has no weights) — no model downloads.
+PARAM = """7767517
+2 2
+Input            input    0 1 input
+Pooling          gmp      1 1 input output 0=0 4=1
+"""
+
+
+def test_mat_numpy_roundtrip():
+    """ncnn.Mat shares memory semantics with numpy — the tensor bridge every
+    real pipeline uses."""
+    import ncnn
+
+    arr = np.arange(12, dtype=np.float32).reshape(3, 4)
+    mat = ncnn.Mat(arr)
+    back = np.array(mat)
+    assert back.shape == (3, 4)
+    assert np.array_equal(back, arr)
+
+
+def test_weightless_graph_inference(tmp_path):
+    """Load a param graph + empty bin, run the Extractor — proves the whole
+    inference engine (layer registry, blob allocator, threading) on-device."""
+    import ncnn
+
+    param = tmp_path / "tiny.param"
+    param.write_text(PARAM)
+    bin_path = tmp_path / "tiny.bin"
+    bin_path.write_bytes(b"")
+
+    net = ncnn.Net()
+    assert net.load_param(str(param)) == 0
+    assert net.load_model(str(bin_path)) == 0
+
+    # ncnn layers operate on (c, h, w) — a 2D array would be pooled per-row.
+    x = np.zeros((1, 4, 4), dtype=np.float32)
+    x[0, 2, 1] = 42.5
+    ex = net.create_extractor()
+    ex.input("input", ncnn.Mat(x))
+    ret, out = ex.extract("output")
+    assert ret == 0
+    result = np.array(out).flatten()
+    assert result.shape == (1,) and result[0] == 42.5
+
+
+def test_cpu_info():
+    import ncnn
+
+    # model-free CPU introspection (big.LITTLE awareness on device)
+    assert ncnn.get_cpu_count() >= 1


### PR DESCRIPTION
Adds [ncnn](https://github.com/Tencent/ncnn), Tencent's mobile-first CNN inference engine. This is the standard "run YOLO on mobile" runtime in the vision ecosystem: users export on desktop (`yolo export format=ncnn`, or pnnx for any torch model, onnx2ncnn for ONNX) and run the resulting `.param`/`.bin` pair on device with this wheel.

## Recipe design

- **Single self-contained pybind11 module** (~2MB wheels): the entire engine is statically linked inside `ncnn.so`. Runtime deps: `numpy` + `opencv-python` (both already published).
- **Env-driven, one patch.** ncnn's `setup.py` appends `EXTRA_CMAKE_ARGS` *after* its own arguments, so recipe overrides win (it force-enables `NCNN_VULKAN=ON`; we turn it back OFF — CPU/NEON is the dependable mobile baseline, Vulkan is a driver lottery on Android and MoltenVK territory on iOS; possible v2).
- **Threading, per platform** (the interesting part):
  - **Android**: real NDK OpenMP, which the toolchain links **statically** — verified with `llvm-nm`: 124 `omp_*` symbols *defined* in the module, none undefined → no `flet-libomp` dependency needed.
  - **iOS**: `NCNN_SIMPLEOMP=ON` — ncnn's own minimal OpenMP runtime, built for exactly this case (AppleClang has no `-fopenmp`). Final deps: libSystem + libc++  only.
- **The one patch** (`pin-version-date.patch`): upstream stamps the wheel version as `MAJOR.MINOR.<build date>` (`time.strftime("%Y%m%d")`), so rebuilding the `1.0.20260526` sdist on any other day would produce a version that mismatches the recipe pin and forge's bookkeeping. The patch pins the date segment to the sdist's release date — builds are reproducible.
- Usual cross-compile hygiene: pybind11 v3 (vendored) uses the new FindPython → explicit `Python_EXECUTABLE/INCLUDE_DIR/LIBRARY` triple; iOS uses `CMAKE_GENERATOR="Unix Makefiles"` (the ninja pip package crashes on the iOS crossenv); Android links with `-Wl,-z,max-page-size=16384` (16KB pages).

## Tests

Model-free but real:
- `Mat` ↔ numpy round-trip (the tensor bridge every pipeline uses).
- **Weightless-graph inference**: a text-`.param` `Input → global-max-Pooling` graph with an empty `.bin`, executed through the full `Net`/`Extractor` machinery — layer registry, blob allocator, and threading all exercised on device with zero model downloads. Also documents the `(c, h, w)` Mat convention that a 2D array silently violates.
- `get_cpu_count()` introspection.

## Not in v1

No Vulkan/GPU (above), no training, no on-device model conversion — pnnx/onnx2ncnn stay desktop tools; the wheel ships the runtime only.