### PR TITLE
recipe: pycares 5.0.1

### DIFF
--- a/.claude/skills/forge-error-catalogue/SKILL.md
+++ b/.claude/skills/forge-error-catalogue/SKILL.md
@@ -80,7 +80,9 @@ instead of re-deriving it.
   fix), **Rust crate with no `target_os="ios"` backend** (`mac_address`, cfg-gate it),
   **`User for pypi.flet.dev:` → `EOFError` at build-tool/host-dep resolution** (the
   index 401s, not the recipe — deterministic locally on a fresh cmake cross-venv,
-  transient/scattered in CI where a rerun clears it).
+  transient/scattered in CI where a rerun clears it). **A vendored lib built by
+  setup.py's OWN cmake call** (arg list hardcoded, so `CMAKE_ARGS` does nothing) →
+  green host-configured library, fix by patching in a `FORGE_CMAKE_ARGS` extend.
 - **Runtime failures** (device/emulator/simulator) — **the Flet 0.86 Android
   `sitepackages.zip` class** (its umbrella entry explains "why only now"):
   `NotADirectoryError` on a bundled data file → **`extract_packages`** meta field;
@@ -104,7 +106,9 @@ instead of re-deriving it.
   `libssl.so.3`/`libcrypto`/`libsqlite` not found, import-name errors, old version
   loaded, **lazy_loader "non-existent stub" (serious_python strips `*.pyi`)**,
   **hidden runtime deps** (keras→scipy; device-emulating venv method),
-  **insightface `root=` PermissionError**, and **iOS app crashes at launch with a
+  **insightface `root=` PermissionError**, **Android-only silent degradation when a lib
+  reads system config through a Java-only API** (c-ares gets no nameservers, seeds
+  `127.0.0.1:53`, every lookup fails while iOS is fine — configure it from Python), and **iOS app crashes at launch with a
   0-byte `console.log` → `dyld: Library not loaded: @rpath/lib<X>.dylib` for a chain
   of interdependent bundled dylibs (pyarrow, llama)** → **serious_python #223**:
   reconcile framework install-ids + `@rpath` deps to the dotted-framework paths

--- a/.claude/skills/forge-error-catalogue/references/failure-catalogue.md
+++ b/.claude/skills/forge-error-catalogue/references/failure-catalogue.md
@@ -803,6 +803,38 @@ run (sherpa's setup.py falls back to a bounded `make -j4`). **Related trap:**
 
 ---
 
+### A vendored native lib is built by setup.py's OWN cmake call — green build, host-configured library
+
+**Cause:** the sdist vendors a C library (`deps/<lib>/`) and `build_ext` shells out to
+`cmake` with an argument list that is a **literal in setup.py**, then links the static
+result via `extra_objects`. No CMake build backend is involved, so `CMAKE_ARGS` (which
+only scikit-build-core reads) is ignored and the vendored lib configures for the build
+host. Nothing errors: repeated arch (macOS arm64 host → `ios_arm64` target) links
+without complaint, and the configure-time feature probes answer for macOS. The wheel is
+green and wrong — either dead at first use, or quietly missing whatever the probes
+turned off. pycares → c-ares 1.34.6.
+
+**Fix:** patch the arg list to be extensible and fill it from a recipe `script_env` var:
+
+```python
+cmake_args.extend(shlex.split(os.environ.get('FORGE_CMAKE_ARGS', '')))
+```
+
+Append **after** upstream's own platform block — repeated `-D` on a cmake command line
+is last-one-wins, so this overrides e.g. `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12` without
+editing upstream's line. Then the usual lanes (`{NDK_ROOT}/build/cmake/android.toolchain.cmake`
++ `{ANDROID_ABI}` + `{ANDROID_API_LEVEL}`; `-DCMAKE_SYSTEM_NAME=iOS` + `{{ sdk }}` /
+`{{ arch }}` / `{{ sdk_version }}`) and `requirements.build: [cmake]`.
+
+**Confirm from the log, not the exit code:** `-- Check for working C compiler:` must name
+the cross compiler (NDK clang / `arm64-apple-ios*-clang`), and the feature macros you
+depend on must have resolved for the target — grep the generated config header under
+`build/<py>/<pkg>/<ver>/build/temp.*/`. For pycares that is `HAVE___SYSTEM_PROPERTY_GET 1`
+and `CARES_THREADS 1` on Android (`import pycares` raises `RuntimeError` outright if
+`ares_threadsafety()` is false, which is a mercy — most losses of this class are silent).
+
+---
+
 ### CMake-driving setup.py keys its build tool on a literal `"-G Ninja"` substring
 
 **Cause:** sherpa-onnx's `cmake/cmake_extension.py` decides make-vs-ninja with
@@ -1794,6 +1826,35 @@ don't need it. Desktop dev machines mask this (scipy is always around).
 `mobile.patch`). **Detection method that catches these before the device does:**
 build a device-emulating desktop venv containing ONLY the wheel's declared deps
 (no jax, no dev leftovers) and run the recipe tests there.
+
+---
+
+### Android only: a library that reads *system configuration* through a Java-only API silently degrades instead of failing
+
+**Cause:** Android 8 removed most `net.*` / config system properties an app can read, and
+the replacements live behind Java APIs (`ConnectivityManager`, `TelephonyManager`, …). A C
+library that supports Android at all usually reaches them through JNI, and needs the app to
+hand it a `JavaVM*` first. Nothing in the Flet/serious-python stack does that, and no pure
+CPython wheel can — so the discovery returns nothing, and libraries of this class then
+**seed a default rather than erroring**, leaving a working object that cannot do its job.
+
+pycares/c-ares is the worked example: `ares_init_sysconfig_android()` needs
+`ares_library_init_jvm()` + `ares_library_init_android()` (neither exposed by pycares),
+falls back to the removed `net.dns1`…`net.dns8` properties, returns `ARES_EFILE` — and
+`ares_init.c` swallows that and installs `127.0.0.1:53` as the sole nameserver. So
+`pycares.Channel()` constructs fine, `channel.servers == ['127.0.0.1:53']`, and every
+lookup fails with `DNSError: (11, 'Could not contact DNS servers')`. iOS is unaffected —
+there c-ares `dlsym`s Apple's configd SPIs out of libSystem and gets the real resolvers.
+
+**Tell:** the same code works on iOS and fails on Android, the error is a *connection*
+failure rather than a configuration error, and the object's config property reads back a
+loopback/default value.
+
+**Fix:** there is no wheel-side fix — configure it explicitly from Python
+(`pycares.Channel(servers=[...])` / `aiodns.DNSResolver(nameservers=[...])`), or read the
+real values on the Java side with pyjnius and pass them in. Document it in the recipe
+README; do not encode a public default in the wheel. A recipe test cannot assert any of
+this (it differs per platform and network) — surface it with a consumer verify-app.
 
 ---
 

--- a/.claude/skills/new-mobile-recipe/SKILL.md
+++ b/.claude/skills/new-mobile-recipe/SKILL.md
@@ -79,10 +79,42 @@ Match the package to one of these shapes. Each maps to a template in `templates/
 | Native library, **ctypes-loaded (shared)** | A pure-Python wrapper `dlopen`s the lib at runtime via `ctypes` (pyzbar→libzbar, python-magic→libmagic) | `templates/meta-flet-lib.yaml` + `templates/build-flet-lib-shared.sh`; see Pattern H |
 | Cython-accelerated pure-Python (poetry-core build script) | `build-backend = "poetry.core.masonry.api"` + `[tool.poetry.build] script` that cythonizes the runtime `.py` files themselves (zeroconf; the Home-Assistant-ecosystem idiom). Forge's PEP 517 path handles poetry-core unchanged | No template — copy `recipes/zeroconf/` (branch `zeroconf`): `script_env REQUIRE_CYTHON: "1"` + a fail-loud patch (upstream swallows compile errors → silent pure-py wheel), test asserts the modules are real extensions |
 | C-ext that links a lib via a `*-config` tool | Compiled C-ext whose `setup.py` shells out to `pg_config`/`mysql_config`/… (psycopg2→libpq, mysqlclient→libmysqlclient) | A **static+PIC** `flet-lib*` (`build-flet-lib.sh` + `-fPIC`) shipping a config-shim, + consumer `script_env`/patch; see Pattern I |
+| **setup.py that drives CMake itself** for a vendored native lib | An sdist that vendors a C library and builds it with its own `subprocess` CMake call inside `build_ext`, then links the static result via `extra_objects` (pycares→c-ares). Not scikit-build-core — the arg list is hardcoded in `setup.py` | No template — copy `recipes/pycares/`: one patch appends `shlex.split(os.environ['FORGE_CMAKE_ARGS'])` to the arg list, `requirements.build: [cmake]`; see "vendored-CMake" deep-dive below |
 | CMake giant, **no sdist AND no setup.py/pyproject.toml** | Upstream's only wheel path is a host==target build script (onnxruntime's `ci_build/build.py`, TF's `build_pip_package_with_cmake.sh`) | No template — copy from `recipes/onnxruntime/` or `recipes/tflite-runtime/` (branches `machine/onnxruntime` / `machine/tflite-runtime`); see "PEP 517 shim" deep-dive below |
 | **Prebuilt-repackage + host_build chain**  | Upstream publishes official prebuilt mobile archives of the native lib AND the consumer's own cmake links + re-ships the `.so` (flet-libonnxruntime→sherpa-onnx) | `build.sh` repackager + consumer `requirements.host_build`; copy from `recipes/flet-libonnxruntime/` + `recipes/sherpa-onnx/` (branch `machine/sherpa-onnx`); see "prebuilt-repackage" deep-dive below |
 
 If unsure, start with **minimal C-extension** and let the build tell you what's missing. Iterate up the table as failures surface.
+
+### Shape deep-dive: setup.py that drives CMake for a vendored lib (pycares)
+
+**When:** the sdist vendors a C library (`deps/<lib>/`) and its `build_ext` shells out to
+`cmake` to build it, then links the resulting static lib into the extension with
+`extra_objects`. It looks like a CMake recipe but no CMake build backend is involved, so
+`CMAKE_ARGS` (which only scikit-build-core reads) does nothing — the argument list is a
+literal in `setup.py`, configured for the build host.
+
+The whole recipe is one patch that makes that list extensible, plus the env var to fill it:
+
+```python
+cmake_args.extend(shlex.split(os.environ.get('FORGE_CMAKE_ARGS', '')))
+```
+
+Append it **after** upstream's own platform block so the recipe's args win — repeated `-D`
+on a cmake command line is last-one-wins, which is how `-DCMAKE_OSX_DEPLOYMENT_TARGET`
+gets overridden without touching upstream's line. Then the usual per-SDK `script_env`
+lanes (`{NDK_ROOT}/build/cmake/android.toolchain.cmake` + `{ANDROID_ABI}` +
+`{ANDROID_API_LEVEL}` on Android; `-DCMAKE_SYSTEM_NAME=iOS` + `{{ sdk }}` / `{{ arch }}` /
+`{{ sdk_version }}` on iOS), and `requirements.build: [cmake]`.
+
+**Why this shape is worth naming: getting it wrong produces a green wheel.** A host-configured
+vendored lib still *links* whenever host and target arch agree (macOS arm64 objects go into an
+`ios_arm64` extension without complaint), and the resulting wheel then fails on device — or
+worse, works while quietly missing a feature the configure step probed for. Verify from the
+build log, not the exit code: `Check for working C compiler:` must name the cross compiler,
+and the feature macros that matter must have resolved for the target (for pycares:
+`HAVE___SYSTEM_PROPERTY_GET` on Android, `Found Threads: TRUE` on both — a threadless c-ares
+makes `import pycares` raise outright). Grep the generated `ares_config.h`-equivalent in
+`build/<py>/<pkg>/<ver>/build/temp.*/` when in doubt.
 
 ### Shape deep-dive: PEP 517 shim for no-sdist CMake giants (onnxruntime, tflite-runtime)
 
@@ -95,7 +127,7 @@ The shim's load-bearing rules (each one bought with a failed build):
 - **Stage the python package fresh on every hook** (overlay / rm+copy from the current slice's build dir into the source root) so the current slice always wins.
 - Prefer **`-D<pkg>_BUILD_SHARED_LIB=OFF` → one statically-linked pybind module**: no ctypes/dylib gate, and it is exactly the wheel shape that works on BOTH platforms today (onnxruntime's Android design turned out to BE the iOS wheel shape; pywhispercpp/ncnn are the same shape).
 - CMake args ride in a recipe `script_env` var (`FORGE_CMAKE_ARGS`) that the shim `shlex.split`s. **Multi-token `-D` values cannot ride inside it** — give linker-flag strings their own env var and let the shim assemble the single `-D` argument (tflite's `FORGE_SHARED_LINKER_FLAGS: -Wl,-z,max-page-size=16384 -L{HOST_PYTHON_HOME}/lib -lpython{py_version_short}`).
-- **Trap — `setup.py` platform predicates:** under the crossenv `platform.system()` returns `"Android"` / `"iOS"`, which may match NO upstream branch → the libs list stays unset and the wheel silently ships **without the pybind `.so`** (onnxruntime extends upstream's predicate to `("Linux", "AIX", "Android", "iOS")`; the Darwin branch stays intact for real macOS builds).
+- **Trap — `setup.py` platform predicates:** under the crossenv `platform.system()` returns `"Android"` / `"iOS"`, which may match NO upstream branch → the libs list stays unset and the wheel silently ships **without the pybind `.so`** (onnxruntime extends upstream's predicate to `("Linux", "AIX", "Android", "iOS")`; the Darwin branch stays intact for real macOS builds). `sys.platform` is the same story one layer down — crossenv sets it to `"android"` / `"ios"` (from the sysconfigdata's `_PYTHON_HOST_PLATFORM`), so `sys.platform.startswith('linux')` and `== 'darwin'` are both False. **Matching nothing is sometimes exactly right**: it is what keeps `-lrt` (no librt in bionic) and a macOS deployment target out of the pycares build, which is why that recipe needs no platform patch at all. Read the branches before assuming you must extend them.
 
 **Real examples:** `machine/onnxruntime:recipes/onnxruntime/` and `machine/tflite-runtime:recipes/tflite-runtime/` — read via `git show <branch>:<path>` if not on those branches. Both are ONE `mobile.patch` (description as text preamble above the first `---` header, per repo convention).
 

--- a/recipes/pycares/README.md
+++ b/recipes/pycares/README.md
@@ -141,7 +141,7 @@ an in-memory query cache per channel and reads no configuration files on either 
 
 Roughly 116–143 KB compressed and 257–445 KB unpacked per slice, essentially all of it the
 one compiled extension with c-ares linked in; `armeabi_v7a` is the smallest. There are no
-data files, and `aiodns` adds about 30 KB of Python.
+data files, and `aiodns` adds a 13 KB pure-Python wheel on top.
 
 ## Things to know
 

--- a/recipes/pycares/README.md
+++ b/recipes/pycares/README.md
@@ -3,16 +3,21 @@
 [`pycares`](https://github.com/saghul/pycares) is a Python binding for
 [c-ares](https://c-ares.org/), an asynchronous DNS resolver written in C. It is what
 [`aiodns`](https://github.com/aio-libs/aiodns) is built on, and `aiodns` in turn is what
-`aiohttp` uses when you ask it to resolve names without blocking a thread.
+[`aiohttp`](https://docs.aiohttp.org/en/stable/) uses when you ask it to resolve names
+without blocking a thread.
 
-The standard library resolves names with `socket.getaddrinfo`, which blocks — asyncio's
-`loop.getaddrinfo` just moves that block onto a thread-pool worker. c-ares speaks DNS over
+The standard library resolves names with
+[`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo),
+which blocks — asyncio's
+[`loop.getaddrinfo`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.getaddrinfo)
+just moves that block onto a thread-pool worker. c-ares speaks DNS over
 UDP itself, so a lookup is genuinely asynchronous and hundreds can be in flight at once.
 That is the reason to reach for it on a phone: a crawler, a scanner, or anything that
 resolves many names at once stops being bounded by the thread pool.
 
-The wheel is small (roughly 120–145 KB compressed per slice) and vendors c-ares 1.34.6
-statically, so nothing else needs to ship with it.
+The wheel is small (roughly 120–145 KB compressed per slice) and vendors
+[c-ares 1.34.6](https://github.com/c-ares/c-ares/releases/tag/v1.34.6) statically, so
+nothing else needs to ship with it.
 
 ## Install
 
@@ -24,11 +29,15 @@ dependencies = [
 ]
 ```
 
-`aiodns` is pure Python and installs straight from PyPI; `pycares` comes from
-pypi.flet.dev. `cffi`, which pycares needs at runtime, is already published there too and
-resolves automatically. IDNA-2008 support is an optional extra (`pycares[idna]`) — without
-it pycares falls back to the standard library's IDNA-2003 codec, which is present in Flet's
-Python builds.
+`aiodns` is pure Python and installs straight from
+[PyPI](https://pypi.org/project/aiodns/); `pycares` comes from
+[pypi.flet.dev](https://pypi.flet.dev). [`cffi`](https://cffi.readthedocs.io/en/stable/),
+which pycares needs at runtime, is already published there too and resolves automatically.
+IDNA-2008 support is an optional extra (`pycares[idna]`, pulling
+[`idna`](https://pypi.org/project/idna/)) — without it pycares falls back to the standard
+library's
+[IDNA-2003 codec](https://docs.python.org/3/library/codecs.html#module-encodings.idna),
+which is present in Flet's Python builds.
 
 ## Examples
 
@@ -44,10 +53,15 @@ See runnable Flet apps in [`examples/`](examples):
 your own.** This is not something the recipe can fix, and it is the one thing that will
 cost you an afternoon if you do not know it.
 
-Android removed the `net.dns1`…`net.dns8` system properties in Android 8, and the
-replacement — `ConnectivityManager.getLinkProperties().getDnsServers()` — is Java-only.
-c-ares can call it, but only if the app first hands it a JVM pointer through
-`ares_library_init_jvm()` / `ares_library_init_android()`, and pycares exposes neither. So
+Android removed the `net.dns1`…`net.dns8` system properties in
+[Android 8](https://developer.android.com/about/versions/oreo/android-8.0-changes), and the
+replacement —
+[`ConnectivityManager`](https://developer.android.com/reference/android/net/ConnectivityManager)`.getLinkProperties()`
++ [`getDnsServers()`](<https://developer.android.com/reference/android/net/LinkProperties#getDnsServers()>)
+— is Java-only. c-ares can call it, but only if the app first hands it a JVM pointer
+through
+[`ares_library_init_jvm()` / `ares_library_init_android()`](https://c-ares.org/docs/ares_library_init_android.html),
+and pycares exposes neither. So
 c-ares' Android config path finds nothing, and rather than failing loudly it falls back to
 a single default server, `127.0.0.1:53`, where nothing is listening. Verified on an API-34
 emulator with this recipe's wheel:
@@ -70,15 +84,22 @@ or, at the pycares layer:
 channel = pycares.Channel(servers=["1.1.1.1", "8.8.8.8"])
 ```
 
-Which resolvers to name is your call — a public one (Cloudflare, Google, Quad9), your own,
-or one your user configures. There is no environment variable for it: `LOCALDOMAIN` and
-`RES_OPTIONS` are honoured, but neither sets servers.
+Which resolvers to name is your call — a public one
+([Cloudflare](https://developers.cloudflare.com/1.1.1.1/),
+[Google](https://developers.google.com/speed/public-dns),
+[Quad9](https://www.quad9.net/)), your own, or one your user configures. There is no
+environment variable for it:
+[`LOCALDOMAIN` and `RES_OPTIONS`](https://man7.org/linux/man-pages/man5/resolv.conf.5.html)
+are honoured, but neither sets servers.
 
 If you need the *device's* resolvers specifically, read them on the Java side with
-[pyjnius](https://flet.dev/docs/cookbook/native-python-apis) via `ConnectivityManager`, then
-pass the addresses into `DNSResolver(nameservers=...)`. If you would rather not deal with
-any of this, `socket.getaddrinfo` (and asyncio's default resolver) uses Android's own
-resolver and always works — you just lose the concurrency that made pycares worth it.
+[pyjnius](https://pyjnius.readthedocs.io/en/latest/) via
+[`ConnectivityManager`](https://developer.android.com/reference/android/net/ConnectivityManager),
+then pass the addresses into `DNSResolver(nameservers=...)`. If you would rather not deal
+with any of this,
+[`socket.getaddrinfo`](https://docs.python.org/3/library/socket.html#socket.getaddrinfo)
+(and asyncio's default resolver) uses Android's own resolver and always works — you just
+lose the concurrency that made pycares worth it.
 
 On **iOS** none of this applies: c-ares reads the system DNS configuration and lookups work
 with no configuration. Verified on the simulator — the real router and ISP resolvers came
@@ -86,7 +107,8 @@ back, and `pypi.flet.dev` resolved through them.
 
 ## Usage in a Flet app
 
-`aiodns` is the API you want; awaiting it from a Flet handler is the whole integration:
+[`aiodns`](https://github.com/aio-libs/aiodns#api) is the API you want; awaiting it from a
+Flet handler is the whole integration:
 
 ```python
 import aiodns
@@ -101,12 +123,16 @@ async def resolve(e):
         await resolver.close()
 ```
 
-`query_dns()` returns pycares 5.x's typed dataclasses — an `A` answer carries
-`ARecordData(addr=...)`, an `MX` answer `MXRecordData(priority=..., exchange=...)`, and so
-on. (`query()` still exists but is deprecated in aiodns 4.x.) `getaddrinfo()` is the
-closest analogue to the stdlib call and returns both address families at once.
+`query_dns()` returns pycares 5.x's
+[typed dataclasses](https://github.com/saghul/pycares/blob/master/docs/channel.rst) — an `A`
+answer carries `ARecordData(addr=...)`, an `MX` answer `MXRecordData(priority=..., exchange=...)`,
+and so on. (`query()` still exists but is deprecated in aiodns 4.x.)
+[`getaddrinfo()`](https://c-ares.org/docs/ares_getaddrinfo.html) is the closest analogue to
+the stdlib call and returns both address families at once.
 
-Resolving many names concurrently is the point of all this:
+Resolving many names concurrently — with
+[`asyncio.gather`](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather) —
+is the point of all this:
 
 ```python
 results = await asyncio.gather(
@@ -117,10 +143,15 @@ results = await asyncio.gather(
 
 ### Threading
 
-There is no `page.run_thread` here and there should not be. pycares gives every channel its
-own c-ares event thread — epoll on Android, kqueue on iOS — inside the wheel, and aiodns
-marshals each completion back with `loop.call_soon_threadsafe`. Awaiting a lookup never
-blocks the UI thread, and the resolver does not need a `SelectorEventLoop`.
+There is no
+[`page.run_thread`](https://flet.dev/docs/controls/page/#flet.Page.run_thread) here and
+there should not be. pycares gives every channel its own c-ares event thread —
+[epoll](https://man7.org/linux/man-pages/man7/epoll.7.html) on Android,
+[kqueue](https://man.freebsd.org/cgi/man.cgi?kqueue) on iOS — inside the wheel, and aiodns
+marshals each completion back with
+[`loop.call_soon_threadsafe`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon_threadsafe).
+Awaiting a lookup never blocks the UI thread, and the resolver does not need a
+[`SelectorEventLoop`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.SelectorEventLoop).
 
 Two consequences worth knowing. A channel is not a free object: each one starts a thread,
 so build one resolver and keep it rather than one per lookup. And `DNSResolver.close()` is
@@ -128,14 +159,17 @@ a coroutine — `await` it, or the daemon thread that tears the channel down kee
 the query queue.
 
 Construct the resolver inside the running loop, not at module import. On Python 3.14
-`asyncio.get_event_loop()` raises outside a running loop, which turns a module-level
-`DNSResolver()` into an import-time crash.
+[`asyncio.get_event_loop()`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop)
+raises outside a running loop, which turns a module-level `DNSResolver()` into an
+import-time crash.
 
 ### Offline vs online
 
-Everything here needs the network by definition. On Android that means the `INTERNET`
-permission, which `flet build` grants by default. Nothing is cached to disk: c-ares keeps
-an in-memory query cache per channel and reads no configuration files on either platform.
+Everything here needs the network by definition. On Android that means the
+[`INTERNET`](https://developer.android.com/reference/android/Manifest.permission#INTERNET)
+permission, which [`flet build`](https://flet.dev/docs/publish/android/#permissions) grants
+by default. Nothing is cached to disk: c-ares keeps an in-memory query cache per channel
+and reads no configuration files on either platform.
 
 ### App size
 
@@ -146,44 +180,53 @@ data files, and `aiodns` adds a 13 KB pure-Python wheel on top.
 ## Things to know
 
 - **`ARES_VERSION` is c-ares', not pycares'.** The vendored library is pinned by the sdist;
-  this wheel carries 1.34.6.
+  this wheel carries [1.34.6](https://github.com/c-ares/c-ares/releases/tag/v1.34.6).
 
 - **`aiodns` pins `pycares>=5.0.0,<6`.** They move together — a pycares bump past 5.x will
   need an aiodns that accepts it.
 
-- **`search()` behaves differently from desktop.** It appends the resolver's search domains,
-  and on Android there are none to append (the same config path that finds no servers finds
-  no domains either). Prefer `query_dns()` in mobile code, where the name you pass is the
+- **[`search()`](https://c-ares.org/docs/ares_search.html) behaves differently from
+  desktop.** It appends the resolver's search domains, and on Android there are none to
+  append (the same config path that finds no servers finds no domains either). Prefer `query_dns()` in mobile code, where the name you pass is the
   name that gets queried.
 
-- **`Channel.set_local_ip()` raises `TypeError` for IPv6 addresses.** An upstream
-  cdef/implementation mismatch, not something this build introduces, and it affects every
-  platform. IPv4 source binding works.
+- **[`Channel.set_local_ip()`](https://github.com/saghul/pycares/blob/master/docs/channel.rst)
+  raises `TypeError` for IPv6 addresses.** An upstream cdef/implementation mismatch, not
+  something this build introduces, and it affects every platform. IPv4 source binding
+  works.
 
-- **On iOS, c-ares reads DNS config through Apple private SPIs.** `ares_sysconfig_mac.c`
+- **On iOS, c-ares reads DNS config through Apple private SPIs.**
+  [`ares_sysconfig_mac.c`](https://github.com/c-ares/c-ares/blob/main/src/lib/ares_sysconfig_mac.c)
   `dlopen`s `libSystem` and `dlsym`s `dns_configuration_copy` / `dns_configuration_free` /
-  `dns_configuration_notify_key`, because upstream found the public `SCDynamicStore` API
-  returned incomplete data. Those symbol names sit in the shipped binary as plain strings
-  where App Store static analysis looks. This is upstream c-ares behaviour on every Apple
+  `dns_configuration_notify_key`, because upstream found the public
+  [`SCDynamicStore`](https://developer.apple.com/documentation/systemconfiguration/scdynamicstore)
+  API returned incomplete data. Those symbol names sit in the shipped binary as plain
+  strings where App Store static analysis looks. This is upstream c-ares behaviour on every Apple
   platform, and removing it would remove DNS discovery with it — but if your app is going
   through App Store review, know it is there.
 
 - **iOS 14+ Local Network privacy can block the resolver you were handed.** iOS commonly
   reports the router's LAN address as a nameserver (a simulator run here got
   `192.168.178.1`), and querying an address on the local subnet needs
-  `NSLocalNetworkUsageDescription` in `Info.plist` and the user's consent. The simulator
-  does not enforce this, so it will not show up in simulator testing. Naming a public
-  resolver explicitly sidesteps it.
+  [`NSLocalNetworkUsageDescription`](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription)
+  in `Info.plist` and the user's consent — see Apple's
+  [TN3179](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy).
+  The simulator does not enforce this, so it will not show up in simulator testing. Naming
+  a public resolver explicitly sidesteps it.
 
 ## Build notes (maintainers)
 
 ### Recipe shape
 
-A plain setuptools sdist with one CFFI extension, plus one patch. pycares' `setup.py`
-builds the vendored `deps/c-ares` with CMake before compiling the extension and links the
-resulting `libcares.a` in through `extra_objects`, but its `cmake_args` list is hardcoded
-and configures for the build host. `mobile.patch` appends `shlex.split(os.environ['FORGE_CMAKE_ARGS'])`
-last, so the recipe's toolchain arguments win over the host defaults — including upstream's
+A plain setuptools sdist with one CFFI extension, plus one patch. pycares'
+[`setup.py`](https://github.com/saghul/pycares/blob/master/setup.py) builds the vendored
+`deps/c-ares` with CMake before compiling the extension and links the resulting
+`libcares.a` in through
+[`extra_objects`](https://setuptools.pypa.io/en/latest/userguide/ext_modules.html), but its
+`cmake_args` list is hardcoded and configures for the build host.
+[`mobile.patch`](patches/mobile.patch) appends
+`shlex.split(os.environ['FORGE_CMAKE_ARGS'])` last, so the toolchain arguments in
+[`meta.yaml`](meta.yaml) win over the host defaults — including upstream's
 `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12`.
 
 That is the entire adaptation. Everything else falls out for free because `sys.platform` is
@@ -191,15 +234,18 @@ That is the entire adaptation. Everything else falls out for free because `sys.p
 branches match: no `-lrt` on Android (bionic has no librt), no macOS deployment target on
 iOS, and the shared defines (`HAVE_CONFIG_H`, `CARES_STATICLIB`) still apply.
 
-CFFI API mode is what makes this straightforward — `ffi.cdef` is declarative and the
+[CFFI API mode](https://cffi.readthedocs.io/en/stable/overview.html#main-mode-of-usage) is
+what makes this straightforward —
+[`ffi.cdef`](https://cffi.readthedocs.io/en/stable/ref.html#ffi-cdef) is declarative and the
 generated `_cares.c` is compiled by the cross compiler, so no host-side probing happens.
 
 ### Things that must stay true
 
 - **`CARES_THREADS` must survive.** `import pycares` raises `RuntimeError` outright if
-  `ares_threadsafety()` is false, so a threadless c-ares is a dead wheel.
-  `test_import_initializes_thread_safe_cares` is the guard; check `Found Threads: TRUE` in
-  the build log if it ever fails.
+  [`ares_threadsafety()`](https://c-ares.org/docs/ares_threadsafety.html) is false, so a
+  threadless c-ares is a dead wheel.
+  [`test_import_initializes_thread_safe_cares`](tests/test_pycares.py) is the guard; check
+  `Found Threads: TRUE` in the build log if it ever fails.
 - **The CMake probes must run against the target.** `HAVE___SYSTEM_PROPERTY_GET` on Android
   and `HAVE_KQUEUE` / `HAVE_EPOLL` for the event thread are all configure-time. A build
   configured for the host produces a green wheel that fails at `Channel()` construction.
@@ -216,14 +262,17 @@ generated `_cares.c` is compiled by the cross compiler, so no host-side probing 
   libSystem and the Python framework.
 - **METADATA:** `Requires-Dist: cffi` present; no `flet-*` promotion (there are no native
   deps).
-- **On device:** the recipe tests, then the `dns-lookup` example against a real network —
-  the tests are deliberately network-free, so they cannot catch a resolver that builds but
-  cannot reach anything.
+- **On device:** [the recipe tests](tests/test_pycares.py), then the
+  [`dns-lookup`](examples/dns-lookup) example against a real network — the tests are
+  deliberately network-free, so they cannot catch a resolver that builds but cannot reach
+  anything.
 
 ### Coverage gaps
 
-The device tests cover import (and with it `ares_library_init` and the thread-safety gate),
-the servers round trip, the full `ares_strerror` table, `ares_inet_pton` validation,
+[The device tests](tests/test_pycares.py) cover import (and with it `ares_library_init` and
+the thread-safety gate), the servers round trip, the full
+[`ares_strerror`](https://c-ares.org/docs/ares_strerror.html) table,
+[`ares_inet_pton`](https://c-ares.org/docs/ares_inet_pton.html) validation,
 argument validation, and one real query against a closed loopback port — which is what
 exercises the event thread and the CFFI callback. They do not do a real lookup, do not
 touch `search()`, `gethostbyaddr()` or `getnameinfo()`, and cannot assert anything about

--- a/recipes/pycares/README.md
+++ b/recipes/pycares/README.md
@@ -1,0 +1,232 @@
+# pycares
+
+[`pycares`](https://github.com/saghul/pycares) is a Python binding for
+[c-ares](https://c-ares.org/), an asynchronous DNS resolver written in C. It is what
+[`aiodns`](https://github.com/aio-libs/aiodns) is built on, and `aiodns` in turn is what
+`aiohttp` uses when you ask it to resolve names without blocking a thread.
+
+The standard library resolves names with `socket.getaddrinfo`, which blocks — asyncio's
+`loop.getaddrinfo` just moves that block onto a thread-pool worker. c-ares speaks DNS over
+UDP itself, so a lookup is genuinely asynchronous and hundreds can be in flight at once.
+That is the reason to reach for it on a phone: a crawler, a scanner, or anything that
+resolves many names at once stops being bounded by the thread pool.
+
+The wheel is small (roughly 120–145 KB compressed per slice) and vendors c-ares 1.34.6
+statically, so nothing else needs to ship with it.
+
+## Install
+
+```toml
+dependencies = [
+    "flet",
+    "aiodns",
+    "pycares",
+]
+```
+
+`aiodns` is pure Python and installs straight from PyPI; `pycares` comes from
+pypi.flet.dev. `cffi`, which pycares needs at runtime, is already published there too and
+resolves automatically. IDNA-2008 support is an optional extra (`pycares[idna]`) — without
+it pycares falls back to the standard library's IDNA-2003 codec, which is present in Flet's
+Python builds.
+
+## Examples
+
+See runnable Flet apps in [`examples/`](examples):
+
+- [`dns-lookup`](examples/dns-lookup) — resolves a hostname to `A`/`AAAA`/`CNAME`/`MX`/`NS`/`TXT`
+  records against either the system resolver or a public one, and shows which nameservers
+  c-ares actually found.
+
+## Read this first: nameservers on Android
+
+**On Android, c-ares finds no system nameservers, and every lookup fails until you supply
+your own.** This is not something the recipe can fix, and it is the one thing that will
+cost you an afternoon if you do not know it.
+
+Android removed the `net.dns1`…`net.dns8` system properties in Android 8, and the
+replacement — `ConnectivityManager.getLinkProperties().getDnsServers()` — is Java-only.
+c-ares can call it, but only if the app first hands it a JVM pointer through
+`ares_library_init_jvm()` / `ares_library_init_android()`, and pycares exposes neither. So
+c-ares' Android config path finds nothing, and rather than failing loudly it falls back to
+a single default server, `127.0.0.1:53`, where nothing is listening. Verified on an API-34
+emulator with this recipe's wheel:
+
+```
+auto-discovered servers: ['127.0.0.1:53']
+[system DNS]                query A -> FAILED DNSError: (11, 'Could not contact DNS servers')
+[explicit 1.1.1.1/8.8.8.8]  query A -> ['54.160.224.51', '54.227.151.68']
+```
+
+Pass the nameservers explicitly and everything works:
+
+```python
+resolver = aiodns.DNSResolver(nameservers=["1.1.1.1", "8.8.8.8"])
+```
+
+or, at the pycares layer:
+
+```python
+channel = pycares.Channel(servers=["1.1.1.1", "8.8.8.8"])
+```
+
+Which resolvers to name is your call — a public one (Cloudflare, Google, Quad9), your own,
+or one your user configures. There is no environment variable for it: `LOCALDOMAIN` and
+`RES_OPTIONS` are honoured, but neither sets servers.
+
+If you need the *device's* resolvers specifically, read them on the Java side with
+[pyjnius](https://flet.dev/docs/cookbook/native-python-apis) via `ConnectivityManager`, then
+pass the addresses into `DNSResolver(nameservers=...)`. If you would rather not deal with
+any of this, `socket.getaddrinfo` (and asyncio's default resolver) uses Android's own
+resolver and always works — you just lose the concurrency that made pycares worth it.
+
+On **iOS** none of this applies: c-ares reads the system DNS configuration and lookups work
+with no configuration. Verified on the simulator — the real router and ISP resolvers came
+back, and `pypi.flet.dev` resolved through them.
+
+## Usage in a Flet app
+
+`aiodns` is the API you want; awaiting it from a Flet handler is the whole integration:
+
+```python
+import aiodns
+
+async def resolve(e):
+    resolver = aiodns.DNSResolver(nameservers=["1.1.1.1"], timeout=5.0, tries=2)
+    try:
+        result = await resolver.query_dns("pypi.flet.dev", "A")
+        for record in result.answer:
+            print(record.name, record.ttl, record.data)
+    finally:
+        await resolver.close()
+```
+
+`query_dns()` returns pycares 5.x's typed dataclasses — an `A` answer carries
+`ARecordData(addr=...)`, an `MX` answer `MXRecordData(priority=..., exchange=...)`, and so
+on. (`query()` still exists but is deprecated in aiodns 4.x.) `getaddrinfo()` is the
+closest analogue to the stdlib call and returns both address families at once.
+
+Resolving many names concurrently is the point of all this:
+
+```python
+results = await asyncio.gather(
+    *(resolver.query_dns(name, "A") for name in names),
+    return_exceptions=True,
+)
+```
+
+### Threading
+
+There is no `page.run_thread` here and there should not be. pycares gives every channel its
+own c-ares event thread — epoll on Android, kqueue on iOS — inside the wheel, and aiodns
+marshals each completion back with `loop.call_soon_threadsafe`. Awaiting a lookup never
+blocks the UI thread, and the resolver does not need a `SelectorEventLoop`.
+
+Two consequences worth knowing. A channel is not a free object: each one starts a thread,
+so build one resolver and keep it rather than one per lookup. And `DNSResolver.close()` is
+a coroutine — `await` it, or the daemon thread that tears the channel down keeps waiting on
+the query queue.
+
+Construct the resolver inside the running loop, not at module import. On Python 3.14
+`asyncio.get_event_loop()` raises outside a running loop, which turns a module-level
+`DNSResolver()` into an import-time crash.
+
+### Offline vs online
+
+Everything here needs the network by definition. On Android that means the `INTERNET`
+permission, which `flet build` grants by default. Nothing is cached to disk: c-ares keeps
+an in-memory query cache per channel and reads no configuration files on either platform.
+
+### App size
+
+Roughly 116–143 KB compressed and 257–445 KB unpacked per slice, essentially all of it the
+one compiled extension with c-ares linked in; `armeabi_v7a` is the smallest. There are no
+data files, and `aiodns` adds about 30 KB of Python.
+
+## Things to know
+
+- **`ARES_VERSION` is c-ares', not pycares'.** The vendored library is pinned by the sdist;
+  this wheel carries 1.34.6.
+
+- **`aiodns` pins `pycares>=5.0.0,<6`.** They move together — a pycares bump past 5.x will
+  need an aiodns that accepts it.
+
+- **`search()` behaves differently from desktop.** It appends the resolver's search domains,
+  and on Android there are none to append (the same config path that finds no servers finds
+  no domains either). Prefer `query_dns()` in mobile code, where the name you pass is the
+  name that gets queried.
+
+- **`Channel.set_local_ip()` raises `TypeError` for IPv6 addresses.** An upstream
+  cdef/implementation mismatch, not something this build introduces, and it affects every
+  platform. IPv4 source binding works.
+
+- **On iOS, c-ares reads DNS config through Apple private SPIs.** `ares_sysconfig_mac.c`
+  `dlopen`s `libSystem` and `dlsym`s `dns_configuration_copy` / `dns_configuration_free` /
+  `dns_configuration_notify_key`, because upstream found the public `SCDynamicStore` API
+  returned incomplete data. Those symbol names sit in the shipped binary as plain strings
+  where App Store static analysis looks. This is upstream c-ares behaviour on every Apple
+  platform, and removing it would remove DNS discovery with it — but if your app is going
+  through App Store review, know it is there.
+
+- **iOS 14+ Local Network privacy can block the resolver you were handed.** iOS commonly
+  reports the router's LAN address as a nameserver (a simulator run here got
+  `192.168.178.1`), and querying an address on the local subnet needs
+  `NSLocalNetworkUsageDescription` in `Info.plist` and the user's consent. The simulator
+  does not enforce this, so it will not show up in simulator testing. Naming a public
+  resolver explicitly sidesteps it.
+
+## Build notes (maintainers)
+
+### Recipe shape
+
+A plain setuptools sdist with one CFFI extension, plus one patch. pycares' `setup.py`
+builds the vendored `deps/c-ares` with CMake before compiling the extension and links the
+resulting `libcares.a` in through `extra_objects`, but its `cmake_args` list is hardcoded
+and configures for the build host. `mobile.patch` appends `shlex.split(os.environ['FORGE_CMAKE_ARGS'])`
+last, so the recipe's toolchain arguments win over the host defaults — including upstream's
+`-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12`.
+
+That is the entire adaptation. Everything else falls out for free because `sys.platform` is
+`android` / `ios` under the crossenv, so none of `setup.py`'s `darwin` / `linux` / `win32`
+branches match: no `-lrt` on Android (bionic has no librt), no macOS deployment target on
+iOS, and the shared defines (`HAVE_CONFIG_H`, `CARES_STATICLIB`) still apply.
+
+CFFI API mode is what makes this straightforward — `ffi.cdef` is declarative and the
+generated `_cares.c` is compiled by the cross compiler, so no host-side probing happens.
+
+### Things that must stay true
+
+- **`CARES_THREADS` must survive.** `import pycares` raises `RuntimeError` outright if
+  `ares_threadsafety()` is false, so a threadless c-ares is a dead wheel.
+  `test_import_initializes_thread_safe_cares` is the guard; check `Found Threads: TRUE` in
+  the build log if it ever fails.
+- **The CMake probes must run against the target.** `HAVE___SYSTEM_PROPERTY_GET` on Android
+  and `HAVE_KQUEUE` / `HAVE_EPOLL` for the event thread are all configure-time. A build
+  configured for the host produces a green wheel that fails at `Channel()` construction.
+- **No extra link flags on either platform.** The iOS `libcares.a` resolves entirely against
+  libSystem, and Android's needs only bionic. `HAVE_LIBRESOLV=1` is set on iOS and puts a
+  cosmetic `-lresolv` in `libcares.pc` and the CMake export, but `CARES_USE_LIBRESOLV` is
+  z/OS-only so no `res_*` symbol is ever referenced, and `setup.py` reads neither file.
+
+### Re-verification checklist
+
+- **Wheel hygiene:** correct `Machine` per ABI, every Android `LOAD` segment aligned
+  `0x4000`, `DT_NEEDED` limited to `libc`/`libm`/`libdl` plus `libpython`, iOS
+  `LC_BUILD_VERSION` platform 2 on device and 7 on the simulators, `otool -L` showing only
+  libSystem and the Python framework.
+- **METADATA:** `Requires-Dist: cffi` present; no `flet-*` promotion (there are no native
+  deps).
+- **On device:** the recipe tests, then the `dns-lookup` example against a real network —
+  the tests are deliberately network-free, so they cannot catch a resolver that builds but
+  cannot reach anything.
+
+### Coverage gaps
+
+The device tests cover import (and with it `ares_library_init` and the thread-safety gate),
+the servers round trip, the full `ares_strerror` table, `ares_inet_pton` validation,
+argument validation, and one real query against a closed loopback port — which is what
+exercises the event thread and the CFFI callback. They do not do a real lookup, do not
+touch `search()`, `gethostbyaddr()` or `getnameinfo()`, and cannot assert anything about
+system nameserver discovery, which differs per platform and per network. pycares exposes no
+`ares_dns_parse`, so there is no way to push a canned wire packet through the parser
+offline.

--- a/recipes/pycares/examples/dns-lookup/.gitignore
+++ b/recipes/pycares/examples/dns-lookup/.gitignore
@@ -1,0 +1,7 @@
+.venv/
+.flet/
+build/
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+uv.lock

--- a/recipes/pycares/examples/dns-lookup/README.md
+++ b/recipes/pycares/examples/dns-lookup/README.md
@@ -7,13 +7,16 @@ footer shows the nameservers c-ares discovered at startup.
 What it demonstrates:
 
 - **Asynchronous DNS inside a Flet app.**
-  [`aiodns.DNSResolver`](https://github.com/aio-libs/aiodns) is awaited straight from a Flet
-  event handler. No thread pool and no `page.run_thread`: c-ares runs its own event thread
-  inside the wheel and aiodns hands results back to the loop, so an in-flight lookup never
-  blocks the UI.
+  [`aiodns.DNSResolver`](https://github.com/aio-libs/aiodns#api) is awaited straight from a
+  Flet event handler. No thread pool and no
+  [`page.run_thread`](https://flet.dev/docs/controls/page/#flet.Page.run_thread): c-ares
+  runs its own event thread inside the wheel and aiodns hands results back to the loop with
+  [`loop.call_soon_threadsafe`](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_soon_threadsafe),
+  so an in-flight lookup never blocks the UI.
 - **The record types you actually query.** `A`, `AAAA`, `CNAME`, `MX`, `NS` and `TXT` all go
-  through the same `query_dns()` call and render from the typed dataclasses pycares 5.x
-  returns, so an `MX` answer shows its priority and a `CNAME` chain shows every hop.
+  through the same `query_dns()` call and render from the [typed dataclasses pycares 5.x
+  returns](https://github.com/saghul/pycares/blob/master/docs/channel.rst), so an `MX`
+  answer shows its priority and a `CNAME` chain shows every hop.
 - **The Android nameserver problem, on screen.** Run this on Android and the footer reads
   `127.0.0.1:53` in red — c-ares cannot read Android's resolver config, so **System DNS**
   fails with `Could not contact DNS servers` while the public-resolver option works. On iOS
@@ -37,4 +40,6 @@ uv run flet build ios-simulator
 ```
 
 An emulator or simulator is enough — both need network access, and Android needs the
-`INTERNET` permission, which `flet build` grants by default.
+[`INTERNET`](https://developer.android.com/reference/android/Manifest.permission#INTERNET)
+permission, which [`flet build`](https://flet.dev/docs/publish/android/#permissions) grants
+by default.

--- a/recipes/pycares/examples/dns-lookup/README.md
+++ b/recipes/pycares/examples/dns-lookup/README.md
@@ -1,0 +1,40 @@
+# pycares DNS lookup
+
+Type a hostname, pick a record type, and resolve it — either through whatever resolver
+c-ares found by itself or through a public one. The answers appear as they come back; the
+footer shows the nameservers c-ares discovered at startup.
+
+What it demonstrates:
+
+- **Asynchronous DNS inside a Flet app.**
+  [`aiodns.DNSResolver`](https://github.com/aio-libs/aiodns) is awaited straight from a Flet
+  event handler. No thread pool and no `page.run_thread`: c-ares runs its own event thread
+  inside the wheel and aiodns hands results back to the loop, so an in-flight lookup never
+  blocks the UI.
+- **The record types you actually query.** `A`, `AAAA`, `CNAME`, `MX`, `NS` and `TXT` all go
+  through the same `query_dns()` call and render from the typed dataclasses pycares 5.x
+  returns, so an `MX` answer shows its priority and a `CNAME` chain shows every hop.
+- **The Android nameserver problem, on screen.** Run this on Android and the footer reads
+  `127.0.0.1:53` in red — c-ares cannot read Android's resolver config, so **System DNS**
+  fails with `Could not contact DNS servers` while the public-resolver option works. On iOS
+  the footer shows the real system resolvers and both options work. This is the single thing
+  to know before shipping pycares in an app; the [recipe README](../../README.md) explains
+  why and what to do about it.
+
+## Try it
+
+[Build](https://flet.dev/docs/publish/) the app, then install it on a device or emulator/simulator:
+
+```bash
+# Android
+uv run flet build apk
+
+# iOS
+uv run flet build ipa
+
+# iOS-Simulator
+uv run flet build ios-simulator
+```
+
+An emulator or simulator is enough — both need network access, and Android needs the
+`INTERNET` permission, which `flet build` grants by default.

--- a/recipes/pycares/examples/dns-lookup/pyproject.toml
+++ b/recipes/pycares/examples/dns-lookup/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "pycares-dns-lookup"
+version = "1.0.0"
+description = "Resolves DNS records with aiodns, against the system resolver or a public one."
+requires-python = ">=3.12"
+
+dependencies = [
+    "flet==0.86.5",
+    "aiodns==4.0.4",
+    "pycares==5.0.1",
+]
+
+[dependency-groups]
+dev = ["flet-cli", "flet-desktop", "flet-web"]
+
+[tool.flet.app]
+path = "src"

--- a/recipes/pycares/examples/dns-lookup/src/lookup.py
+++ b/recipes/pycares/examples/dns-lookup/src/lookup.py
@@ -1,0 +1,43 @@
+import dataclasses
+
+import aiodns
+import pycares
+
+RECORD_TYPES = ("A", "AAAA", "CNAME", "MX", "NS", "TXT")
+PUBLIC_NAMESERVERS = ["1.1.1.1", "8.8.8.8"]
+
+_TYPE_NAMES = {
+    getattr(pycares, name): name.removeprefix("QUERY_TYPE_")
+    for name in dir(pycares)
+    if name.startswith("QUERY_TYPE_")
+}
+
+
+def system_nameservers():
+    """What c-ares discovered on its own — ['127.0.0.1:53'] means it found none."""
+    channel = pycares.Channel()
+    try:
+        return channel.servers
+    finally:
+        channel.close()
+
+
+def _value(field):
+    return field.decode(errors="replace") if isinstance(field, bytes) else str(field)
+
+
+def describe(record):
+    """One line per answer: name, type, ttl, then the record-specific payload."""
+    payload = " ".join(_value(v) for v in dataclasses.astuple(record.data))
+    kind = _TYPE_NAMES.get(record.type, record.type)
+    return f"{record.name}  {kind}  ttl={record.ttl}\n  {payload}"
+
+
+async def lookup(host, qtype, nameservers):
+    """Resolve one record type. `nameservers=None` uses whatever c-ares found."""
+    resolver = aiodns.DNSResolver(nameservers=nameservers, timeout=5.0, tries=2)
+    try:
+        result = await resolver.query_dns(host, qtype)
+        return [describe(record) for record in result.answer]
+    finally:
+        await resolver.close()

--- a/recipes/pycares/examples/dns-lookup/src/main.py
+++ b/recipes/pycares/examples/dns-lookup/src/main.py
@@ -1,0 +1,73 @@
+import flet as ft
+from lookup import PUBLIC_NAMESERVERS, RECORD_TYPES, lookup, system_nameservers
+
+
+async def main(page: ft.Page):
+    """Resolve a name on demand and list the answers."""
+    discovered = system_nameservers()
+    # c-ares cannot read Android's resolver config, so it falls back to loopback.
+    system_works = not all(s.startswith("127.") for s in discovered)
+
+    async def resolve(_):
+        """Run one query and refill the answer list."""
+        answers.controls.clear()
+        spinner.visible = True
+        page.update()
+
+        servers = None if source.value == "system" else PUBLIC_NAMESERVERS
+        try:
+            lines = await lookup(host.value.strip(), qtype.value, servers)
+            answers.controls.extend(
+                ft.Text(line, size=12, font_family="monospace")
+                for line in lines or ["no answer records"]
+            )
+        except Exception as e:
+            answers.controls.append(
+                ft.Text(f"{type(e).__name__}: {e}", color=ft.Colors.ERROR)
+            )
+        spinner.visible = False
+        page.update()
+
+    host = ft.TextField(label="Host", value="pypi.flet.dev", expand=True)
+    qtype = ft.Dropdown(
+        value="A",
+        width=110,
+        options=[ft.DropdownOption(key=t) for t in RECORD_TYPES],
+    )
+    source = ft.RadioGroup(
+        value="system" if system_works else "public",
+        content=ft.Row(
+            controls=[
+                ft.Radio(value="system", label="System DNS"),
+                ft.Radio(value="public", label=", ".join(PUBLIC_NAMESERVERS)),
+            ],
+        ),
+    )
+    spinner = ft.ProgressRing(visible=False, width=18, height=18)
+    answers = ft.ListView(expand=True, spacing=6)
+
+    page.appbar = ft.AppBar(title=ft.Text("DNS lookup"), center_title=True)
+    page.add(
+        ft.SafeArea(
+            expand=True,
+            content=ft.Column(
+                controls=[
+                    ft.Row(controls=[host, qtype]),
+                    source,
+                    ft.Row(
+                        controls=[ft.Button("Look up", on_click=resolve), spinner]
+                    ),
+                    ft.Divider(),
+                    answers,
+                    ft.Text(
+                        "c-ares found: " + ", ".join(discovered),
+                        size=11,
+                        color=None if system_works else ft.Colors.ERROR,
+                    ),
+                ],
+            ),
+        )
+    )
+
+
+ft.run(main)

--- a/recipes/pycares/meta.yaml
+++ b/recipes/pycares/meta.yaml
@@ -1,0 +1,32 @@
+package:
+  name: pycares
+  version: "5.0.1"
+
+build:
+  number: 1
+  script_env:
+    # pycares' setup.py builds the vendored c-ares (deps/c-ares) with CMake before
+    # compiling the CFFI extension, using a hardcoded argument list that configures
+    # for the build host. mobile.patch makes it append FORGE_CMAKE_ARGS so the
+    # static libcares.a folded into pycares/_cares*.so is built for the target.
+# {% if sdk == 'android' %}
+    FORGE_CMAKE_ARGS: >-
+      -DCMAKE_TOOLCHAIN_FILE={NDK_ROOT}/build/cmake/android.toolchain.cmake
+      -DANDROID_ABI={ANDROID_ABI}
+      -DANDROID_NATIVE_API_LEVEL={ANDROID_API_LEVEL}
+# {% else %}
+    FORGE_CMAKE_ARGS: >-
+      -DCMAKE_SYSTEM_NAME=iOS
+      -DCMAKE_OSX_SYSROOT={{ sdk }}
+      -DCMAKE_OSX_DEPLOYMENT_TARGET={{ sdk_version }}
+      -DCMAKE_OSX_ARCHITECTURES={{ arch }}
+# {% endif %}
+
+requirements:
+  build:
+    # setup.py shells out to `cmake` for the vendored c-ares; the build image
+    # isn't guaranteed to have one.
+    - cmake
+
+patches:
+  - mobile.patch

--- a/recipes/pycares/patches/mobile.patch
+++ b/recipes/pycares/patches/mobile.patch
@@ -1,0 +1,32 @@
+Cross-compile the vendored c-ares.
+
+pycares' setup.py builds deps/c-ares with CMake before compiling the CFFI
+extension, but its cmake_args list is hardcoded and configures for the build
+host — a mobile-forge build would fold a macOS libcares.a into an Android/iOS
+_cares*.so. Append FORGE_CMAKE_ARGS (set by the recipe) so the vendored library
+is configured for the target.
+
+diff -ruN a/setup.py b/setup.py
+--- a/setup.py	2026-01-01 13:01:25
++++ b/setup.py	2026-08-31 11:53:32
+@@ -2,6 +2,7 @@
+ # -*- coding: utf-8 -*-
+ 
+ import os
++import shlex
+ import shutil
+ import subprocess
+ import sys
+@@ -77,6 +78,12 @@
+                     if '/MT' in str(flag):
+                         cmake_args.append('-DCARES_MSVC_STATIC_RUNTIME=ON')
+                         break
++
++        # Cross-compilation (mobile-forge): the vendored c-ares must be configured
++        # for the target, not for the build host. The recipe supplies the toolchain
++        # file / sysroot / architecture args here; being last, they win over the
++        # host defaults set above.
++        cmake_args.extend(shlex.split(os.environ.get('FORGE_CMAKE_ARGS', '')))
+ 
+         # Run CMake configure
+         print(f"Configuring c-ares with CMake in {build_temp}")

--- a/recipes/pycares/tests/test_pycares.py
+++ b/recipes/pycares/tests/test_pycares.py
@@ -1,0 +1,127 @@
+"""pycares wraps c-ares (vendored, statically linked into pycares/_cares*.so)
+through CFFI. These tests stay off the network: everything either runs
+in-process or talks to a loopback port with nothing listening on it."""
+
+import threading
+
+import pycares
+
+
+def _noop_sock_state_cb(fd, readable, writable):
+    """Suppresses the c-ares event thread so a channel stays inert."""
+
+
+def test_import_initializes_thread_safe_cares():
+    """Importing pycares runs ares_library_init() and hard-fails unless c-ares
+    reports thread safety, so a successful import already proves the vendored
+    library is the cross-compiled one and that CARES_THREADS survived."""
+    assert isinstance(pycares.ARES_VERSION, str) and pycares.ARES_VERSION
+    assert pycares.ARES_SOCKET_BAD == -1
+    assert pycares.QUERY_TYPE_A != pycares.QUERY_TYPE_AAAA
+
+
+def test_servers_roundtrip():
+    """Explicit nameservers survive ares_set_servers_csv/ares_get_servers_csv.
+    This is the supported way to configure a channel on a platform where c-ares
+    cannot read the system resolver config — which is every Android build."""
+    channel = pycares.Channel(
+        servers=["8.8.8.8", "1.1.1.1"], sock_state_cb=_noop_sock_state_cb
+    )
+    try:
+        # c-ares echoes back the port it filled in, e.g. "8.8.8.8:53".
+        servers = channel.servers
+        assert len(servers) == 2, servers
+        assert servers[0].startswith("8.8.8.8"), servers
+        assert servers[1].startswith("1.1.1.1"), servers
+
+        channel.servers = ["9.9.9.9"]
+        assert channel.servers[0].startswith("9.9.9.9"), channel.servers
+    finally:
+        channel.close()
+
+
+def test_strerror_covers_every_error_code():
+    """Every code in the errno table maps to a message through ares_strerror()."""
+    assert pycares.errno.errorcode[pycares.errno.ARES_ENOTFOUND] == "ARES_ENOTFOUND"
+    for code in pycares.errno.errorcode:
+        message = pycares.errno.strerror(code)
+        assert isinstance(message, str) and message, code
+
+
+def test_address_parsing_rejects_garbage():
+    """Address arguments go through ares_inet_pton in the extension; malformed
+    input must raise rather than reach the resolver."""
+    channel = pycares.Channel(sock_state_cb=_noop_sock_state_cb)
+    try:
+        channel.set_local_ip("127.0.0.1")
+
+        for bad in ("not-an-ip", "999.999.999.999"):
+            try:
+                channel.set_local_ip(bad)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"set_local_ip({bad!r}) did not raise")
+    finally:
+        channel.close()
+
+
+def test_query_argument_validation():
+    """Query type/class and callable checks happen in Python, before any
+    ares_query_dnsrec call — so they hold even with no servers configured."""
+    channel = pycares.Channel(sock_state_cb=_noop_sock_state_cb)
+    try:
+        for kwargs in (
+            {"query_type": -1},
+            {"query_type": pycares.QUERY_TYPE_A, "query_class": -1},
+        ):
+            try:
+                channel.query("example.com", callback=lambda *a: None, **kwargs)
+            except ValueError:
+                pass
+            else:
+                raise AssertionError(f"query({kwargs}) did not raise")
+
+        try:
+            channel.query("example.com", pycares.QUERY_TYPE_A, callback=None)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError("non-callable callback did not raise")
+    finally:
+        channel.close()
+
+
+def test_query_against_closed_local_port_reports_error():
+    """A query aimed at a loopback port with nothing listening drives the whole
+    stack — socket setup, the c-ares event thread (epoll on Android, kqueue on
+    iOS) and the CFFI callback back into Python — and must deliver a failure to
+    the callback rather than hang or crash."""
+    done = threading.Event()
+    seen = []
+
+    def on_result(result, errorno):
+        seen.append((result, errorno))
+        done.set()
+
+    channel = pycares.Channel(
+        servers=["127.0.0.1"],
+        udp_port=1,
+        tcp_port=1,
+        timeout=0.5,
+        tries=1,
+        flags=pycares.ARES_FLAG_NOSEARCH,
+    )
+    try:
+        channel.query("example.invalid", pycares.QUERY_TYPE_A, callback=on_result)
+        assert done.wait(30), "callback never fired"
+    finally:
+        channel.close()
+
+    result, errorno = seen[0]
+    assert result is None
+    assert errorno in (
+        pycares.errno.ARES_ECONNREFUSED,
+        pycares.errno.ARES_ETIMEOUT,
+        pycares.errno.ARES_ESERVFAIL,
+    ), pycares.errno.strerror(errorno)


### PR DESCRIPTION
Adds a recipe for [pycares](https://github.com/saghul/pycares) 5.0.1 — Python bindings for [c-ares](https://c-ares.org/), the asynchronous DNS resolver that [aiodns](https://github.com/aio-libs/aiodns) is built on. Requested in [flet#6805](https://github.com/flet-dev/flet/discussions/6805).

- [Docs](recipes/pycares/README.md)
- [Example](recipes/pycares/examples/dns-lookup)

`socket.getaddrinfo` blocks, and asyncio only moves that block onto a thread-pool worker — so resolution is bounded by the pool, not the network. c-ares speaks DNS itself and keeps hundreds of lookups in flight, which is the reason to carry it on a phone. aiodns needs no recipe of its own (pure Python on PyPI) and `cffi` is already published, so this one recipe is the whole ask.

## Recipe shape

A plain setuptools sdist with one CFFI (API-mode) extension and **one patch** — but a shape this repo hasn't had before. pycares' `setup.py` builds the vendored `deps/c-ares` (1.34.6) with **its own** `subprocess` CMake call inside `build_ext`, then links the resulting `libcares.a` through `extra_objects`. No CMake build backend is involved, so `CMAKE_ARGS` does nothing — the argument list is a literal in `setup.py`, configured for the build host.

`mobile.patch` makes that list extensible, in one line of substance:

```python
cmake_args.extend(shlex.split(os.environ.get('FORGE_CMAKE_ARGS', '')))
```

Appended **after** upstream's own platform block so the recipe's toolchain arguments win — repeated `-D` on a cmake command line is last-one-wins, which is also how upstream's `-DCMAKE_OSX_DEPLOYMENT_TARGET=10.12` gets overridden without editing its line.

**Getting this wrong fails green.** A host-configured `libcares.a` still links whenever host and target arch agree (macOS arm64 objects go into an `ios_arm64` extension without complaint), and the configure-time probes answer for macOS. Two of those probes are load-bearing and were verified in the build logs: `CARES_THREADS` (`import pycares` raises `RuntimeError` outright if `ares_threadsafety()` is false) and `HAVE___SYSTEM_PROPERTY_GET` / epoll / kqueue for the event thread.

That is the entire adaptation. Everything else falls out because `sys.platform` is `android`/`ios` under the crossenv, so none of `setup.py`'s `darwin`/`linux`/`win32` branches match — which is exactly right: no `-lrt` on Android (bionic has no librt), no macOS deployment target on iOS. No extra link flags on either platform; the iOS `libcares.a` resolves entirely against libSystem and Android's against bionic.

## Validation

6/6 slices built clean first try. CI green across the full matrix — 18 wheels (3.12/3.13/3.14 × 6 slices) — with the on-device `console.log` artifacts showing `6 passed` / `EXIT 0` on both platforms. Also run locally on an API-34 arm64 emulator and an iPhone 16 Pro simulator.

Wheel hygiene per slice: correct `Machine` per ABI, every Android `LOAD` segment aligned `0x4000`, `DT_NEEDED` limited to `libc`/`libm`/`libdl` plus `libpython`, iOS `LC_BUILD_VERSION` platform 2 on device and 7 on the simulators, `otool -L` showing only libSystem and the Python framework. ~116–143 KB compressed per slice.

The recipe tests are deliberately network-free, so they cannot catch a resolver that builds but can't reach anything. The `dns-lookup` example was run against a real network on both platforms to close that gap — and that is what surfaced the consumer note below.

## Changes

- `recipes/pycares/` — `meta.yaml`, one patch, 6 on-device tests, `README.md`, and a runnable example.
- `.claude/skills/` — the new recipe shape in `new-mobile-recipe`, plus two `forge-error-catalogue` entries (the green-but-host-configured build class above, and the Android runtime class below). Separable; drop the commit if you'd rather keep skills out of a recipe PR.