### PR TITLE
recipe: Pillow's native libs are link-time only on iOS

### DIFF
--- a/.claude/skills/local-recipe-testing/SKILL.md
+++ b/.claude/skills/local-recipe-testing/SKILL.md
@@ -138,6 +138,15 @@ for i in $(seq 1 30); do grep EXIT "$DATA/Library/Caches/console.log" 2>/dev/nul
 
 12. **Verify the staged tests + the on-device test COUNT — staging can fail silently.** `stage_recipe.sh` wipes and re-stages `recipe_tests/`; if the invocation ever fails without you noticing (a scripted loop with a bad variable — zsh does NOT word-split unquoted `$VAR` like bash, so a `for r in $RECIPES`-style loop can pass the whole list as ONE argument), the PREVIOUS recipe's tests are still staged and run happily, reporting "N passed" for the wrong package. Two cheap checks after staging: `ls tests/recipe-tester/recipe_tests/` shows YOUR test files, and the "N passed" in console.log matches your recipe's test count. (Bit during the h5py→keras loop: the same 4 stale h5py tests "passed" three times.) **Stronger still — verify the built APK's CONTENTS, not just `recipe_tests/`:** a build that *fails* can leave a STALE `build/apk/recipe-tester.apk` that installs the wrong app entirely. `unzip -l build/apk/recipe-tester.apk` should show your recipe's test `.py` inside `app.zip` AND (for a native recipe) `lib/<abi>/lib*.so` for its libs. Caught an opaque run that silently installed a stale pysodium APK and reported "2 passed" for the wrong package. When in doubt nuke `build/apk` too, not just `build/site-packages`.
 
+12a. **zsh eats `:` after a bare `$var` — `"$ref:path"` is a git-query landmine.** zsh applies
+    history-style modifiers to an unbraced parameter, so `"$r:recipes/foo/meta.yaml"` parses `:r`
+    (remove-extension) and expands to `refs/heads/my-branchecipes/foo/meta.yaml`. `git show` on
+    that returns nothing, exits non-zero, and a `2>/dev/null` loop reports a confident, wrong
+    **negative** across every ref. Always brace it: `"${r}:path"`. This produced a false "that
+    fix exists on no branch" claim about work that was sitting on `examples-and-docs`. General
+    rule: **a search that returns a surprising negative is a bug until proven otherwise** — spot-check
+    one case you are certain about before reporting the absence as evidence.
+
 ## Model assets & test-only deps
 
 `stage_recipe.sh` copies **every** file in `recipes/<pkg>/tests/` into the app (`cp -r tests/. recipe_tests/`), so a model dropped next to the test file becomes an app asset. Two tiers:

--- a/.claude/skills/new-mobile-recipe/references/recipe-patterns.md
+++ b/.claude/skills/new-mobile-recipe/references/recipe-patterns.md
@@ -648,6 +648,50 @@ see the `forge-ci` skill.
 
 ## Cross-cutting conventions
 
+### `host` vs `host_build` is a PER-PLATFORM question
+
+`host` promotes the dep to a runtime `Requires-Dist`, so every consuming app installs that
+wheel. `host_build` puts it in the cross env for the link and leaves the metadata alone. Both
+install into the SAME `opt/` tree, so header/lib probing is identical either way — the only
+difference is the wheel's metadata.
+
+**The test is the payload, not the recipe, and the answer usually differs per SDK:**
+
+| `opt/lib` holds | verdict |
+| --- | --- |
+| `.a` only | `host_build` — absorbed at link time, unloadable at runtime |
+| `.so` / `.dylib` | `host` — a real runtime dep; flet stages it into jniLibs |
+| both | `host`, and delete the dead `.a` in build.sh |
+
+Most `flet-lib*` build **shared on Android and static on iOS**, so the same lib needs both. Guard
+the KEY, not the list item:
+
+```yaml
+requirements:
+# {% if sdk == 'android' %}
+  host:
+    - flet-libjpeg 3.0.90
+# {% else %}
+  host_build:
+    - flet-libjpeg 3.0.90
+# {% endif %}
+```
+
+Confirm before moving anything, per platform:
+
+```bash
+llvm-readelf -d <ext>.so | grep NEEDED        # android: lib listed => runtime => host
+nm -u <ext>.so | grep -ci <libsym>            # ios: 0 undefined => absorbed => host_build
+```
+
+An audit that checks only Android will clear libs that are archives-only on iOS — that mistake
+is already recorded in AGENTS.md's sweep, which cleared flet-libjpeg/libxml2/libgeos/libfreetype
+as "runtime .so payloads". True there, false on iOS. `pillow` (all three of its libs), `pymssql`
+and `scipy` are the fixed precedents.
+
+Getting it wrong the safe way costs a download; getting it wrong the unsafe way — moving a lib
+something actually `dlopen`s — is a runtime crash on device, so verify per consumer.
+
 ### Version specifiers in requirements
 
 Forge parses `requirements.host` / `requirements.build` strings per `build.py:67-78`:

--- a/recipes/pillow/meta.yaml
+++ b/recipes/pillow/meta.yaml
@@ -3,11 +3,26 @@ package:
   version: "12.2.0"
 
 requirements:
+  # PNG support is internal: libpng is not used.
+  #
+  # All three are linked STATICALLY into the extensions on iOS and dynamically on
+  # Android, so where they belong differs by platform. Under `host` they become a
+  # runtime Requires-Dist and every consuming app installs the wheel; on iOS that
+  # is ~16 MB of .a already folded into _imaging.so / _webp.so and unloadable at
+  # runtime. `host_build` extracts them for the link without putting them in the
+  # metadata. Android keeps `host`: there the payload is a real .so the extensions
+  # carry as DT_NEEDED, and flet stages it into jniLibs.
+# {% if sdk == 'android' %}
   host:
-    # PNG support is internal: libpng is not used.
     - flet-libjpeg 3.0.90
     - flet-libfreetype 2.13.3
     - flet-libwebp 1.6.0
+# {% else %}
+  host_build:
+    - flet-libjpeg 3.0.90
+    - flet-libfreetype 2.13.3
+    - flet-libwebp 1.6.0
+# {% endif %}
 
 # {% if not version or version >= (12,0,0) %}
 # pillow >= 12.x  (12.x drops `self.add_imaging_libs = ""` from


### PR DESCRIPTION
`flet-libjpeg`, `flet-libfreetype` and `flet-libwebp` were under `requirements.host` for both platforms, which promotes them to a runtime `Requires-Dist`. On iOS all three link **statically**, so every consuming app downloaded and installed roughly **16 MB of `.a`** — 8.5 jpeg, 4.3 freetype, 3.2 webp — that is already folded into `_imaging.so` and `_webp.so` and can never be loaded.

Android is the opposite case and keeps `host`: there the payload is a real `.so` the extensions carry as `DT_NEEDED` and flet stages into `jniLibs`. Same recipe, same file, opposite verdicts — so this is a per-SDK split, not a move.

## Evidence

Measured on the rebuilt wheels, both directions:

| | iOS | Android |
|---|---|---|
| `Requires-Dist` for the three | **dropped** | **retained** |
| symbols defined in-extension | 82 jpeg, 175 freetype, 117 webp | — |
| undefined jpeg/FT/WebP refs | **0** | 22 jpeg, resolved at runtime |
| load commands | `libSystem`/`libz`/`libbz2` only | `DT_NEEDED libjpeg.so` |

Zero undefined references is the point: nothing was ever resolved at runtime on iOS, so the metadata dependency only ever caused a download.

Feature detection is unchanged — `--- JPEG support available`, `--- FREETYPE2 support available`, `--- WEBP support available` on iOS — because `host` and `host_build` `pip_install` into the *same* cross-env `opt/` tree. Only the wheel metadata differs, so Pillow's `setup.py` probe of `compiler.include_dirs` sees an identical filesystem either way.

## Validation

CI 10/10 with `mobile_test_pythons=ALL`, dispatched with `prebuild_recipes="flet-libwebp"` since that lib is not published yet. **On-device 11/11 EXIT 0 on all six Python × platform combinations**, plus locally on an Android arm64 API 34 emulator and an iOS 18.6 simulator, where the built `.app` contained zero `.a` files.

The metadata split holds on every one of the 18 CI-built wheels — 3 `flet-lib` `Requires-Dist` on all 9 Android slices, 0 on all 9 iOS slices, across cp312/cp313/cp314.

## No build-number bump

`pillow-12.2.0-2` has never been published — only `-1` is on the index — so this corrects what `-2` means rather than superseding a shipped wheel. Had `-2` shipped, this would need `-3`: the code is identical but the dependency set is not.

## Scope

Deliberately **not** in this PR, each needing its own per-consumer verification:

- `lxml` → `flet-libxml2` + `flet-libxslt` (~6.6 MB)
- `shapely` → `flet-libgeos` (~8 MB)
- `flet-libjpeg`'s **Android** wheel carries 14.2 MB of dead `.a` beside its needed 1.3 MB `.so`. `host_build` cannot fix that one — it wants deleting in `build.sh`, as `flet-libwebp` already does — and all 7 consumers need checking first; only Pillow is proven to load it dynamically.

Worth noting the practical impact is bounded: serious_python's default junk list strips `**.a`/`**.h`, so these never reached a device. The cost was CI downloads on every cold runner, clean-build disk, and the full payload shipping for anyone who sets `cleanup.packages = false`.

## Also included

The two findings folded into the skills, so the next person does not re-derive them:

- `new-mobile-recipe/references/recipe-patterns.md` — a "`host` vs `host_build` is a per-platform question" section: the payload decides, the verify command per platform, the Jinja-guard shape, and the note that the existing sweep's conclusion was Android-only.
- `local-recipe-testing/SKILL.md` — zsh applies history-style modifiers to an unbraced parameter, so `"$ref:path"` parses `:r` and silently queries a mangled path. It made a `git show` sweep across every ref report a fix as absent when it was sitting on `examples-and-docs`.